### PR TITLE
Add run target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,3 +27,6 @@ clean:
 	rm -rf ./bin/os.bin
 	rm -rf ${FILES}
 	rm -rf ./build/kernelfull.o
+.PHONY: run
+run:
+	qemu-system-i386 -drive format=raw,file=./bin/os.bin


### PR DESCRIPTION
## Summary
- allow launching the built OS image via `make run`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68630b6a01108324aeca6a600738ff2a