### PR TITLE
Add run target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,3 +27,6 @@ clean:
 	rm -rf ./bin/os.bin
 	rm -rf ${FILES}
 	rm -rf ./build/kernelfull.o
+.PHONY: run
+run:
+	qemu-system-i386 -drive format=raw,file=./bin/os.bin

--- a/agents.md
+++ b/agents.md
@@ -1,3 +1,11 @@
+## Prerequisites
+
+- Ensure you have `nasm`, `i686-elf-gcc` (or compatible cross-compiler) and `i686-elf-ld` on your `PATH`.
+- To bootstrap a cross-toolchain, simply run the root-level script:
+  ```
+  ./build-toolchain.sh
+  ```
+
 ## Reference Kernel Examples
 
 The `example_kernel_src/` directory contains small, self-contained demos of kernel subsystems (boot, C setup, simple syscall, VGA text, paging, etc.).


### PR DESCRIPTION
## Summary
- allow launching the built OS image via `make run`
- document prerequisites and reference kernel examples for contributors

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68630b6a01108324aeca6a600738ff2a