### PR TITLE
Add memory, string, and IO utilities

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,8 @@
-FILES = ./build/kernel.asm.o ./build/kernel.o
+FILES = ./build/kernel.asm.o \
+	./build/kernel.o \
+	./build/memory.o \
+	./build/string.o \
+	./build/io.o
 INCLUDES = -I./src
 FLAGS = -g -ffreestanding -falign-jumps -falign-functions -falign-labels -falign-loops -fstrength-reduce -fomit-frame-pointer -finline-functions -Wno-unused-function -fno-builtin -Werror -Wno-unused-label -Wno-cpp -Wno-unused-parameter -nostdlib -nostartfiles -nodefaultlibs -Wall -O0 -Iinc
 
@@ -20,6 +24,15 @@ all: ./bin/boot.bin ./bin/kernel.bin
 
 ./build/kernel.o: ./src/kernel.c
 	i686-elf-gcc $(INCLUDES) $(FLAGS) -std=gnu99 -c ./src/kernel.c -o ./build/kernel.o
+
+./build/memory.o: ./src/memory/memory.c
+	i686-elf-gcc $(INCLUDES) $(FLAGS) -std=gnu99 -c ./src/memory/memory.c -o ./build/memory.o
+
+./build/string.o: ./src/string/string.c
+	i686-elf-gcc $(INCLUDES) $(FLAGS) -std=gnu99 -c ./src/string/string.c -o ./build/string.o
+
+./build/io.o: ./src/io/io.asm
+	nasm -f elf -g ./src/io/io.asm -o ./build/io.o
 
 clean:
 	rm -rf ./bin/boot.bin

--- a/src/io/io.asm
+++ b/src/io/io.asm
@@ -1,0 +1,50 @@
+section .asm
+
+global insb
+global insw
+global outb
+global outw
+
+insb:
+    push ebp
+    mov ebp, esp
+
+    xor eax, eax
+    mov edx, [ebp+8]
+    in al, dx
+
+    pop ebp
+    ret
+
+insw:
+    push ebp
+    mov ebp, esp
+
+    xor eax, eax
+    mov edx, [ebp+8]
+    in ax, dx
+
+    pop ebp
+    ret
+
+outb:
+    push ebp
+    mov ebp, esp
+
+    mov eax, [ebp+12]
+    mov edx, [ebp+8]
+    out dx, al
+
+    pop ebp
+    ret
+
+outw:
+    push ebp
+    mov ebp, esp
+
+    mov eax, [ebp+12]
+    mov edx, [ebp+8]
+    out dx, ax
+
+    pop ebp
+    ret

--- a/src/io/io.h
+++ b/src/io/io.h
@@ -1,0 +1,9 @@
+#ifndef IO_H
+#define IO_H
+
+unsigned char insb(unsigned short port);
+unsigned short insw(unsigned short port);
+void outb(unsigned short port, unsigned char val);
+void outw(unsigned short port, unsigned short val);
+
+#endif

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -1,4 +1,6 @@
 #include "kernel.h"
+#include "string/string.h"
+#include "memory/memory.h"
 #include <stddef.h>
 #include <stdint.h>
 
@@ -49,16 +51,6 @@ void terminal_initialize()
 }
 
 
-size_t strlen(const char* str)
-{
-    size_t len = 0;
-    while(str[len])
-    {
-        len++;
-    }
-
-    return len;
-}
 
 void print(const char* str)
 {

--- a/src/memory/memory.c
+++ b/src/memory/memory.c
@@ -1,0 +1,37 @@
+#include "memory.h"
+
+void* memset(void* ptr, int c, size_t size)
+{
+    char* c_ptr = (char*) ptr;
+    for (int i = 0; i < size; i++)
+    {
+        c_ptr[i] = (char) c;
+    }
+    return ptr;
+}
+
+int memcmp(void* s1, void* s2, int count)
+{
+    char* c1 = s1;
+    char* c2 = s2;
+    while(count-- > 0)
+    {
+        if (*c1++ != *c2++)
+        {
+            return c1[-1] < c2[-1] ? -1 : 1;
+        }
+    }
+
+    return 0;
+}
+
+void* memcpy(void* dest, void* src, int len)
+{
+    char *d = dest;
+    char *s = src;
+    while(len--)
+    {
+        *d++ = *s++;
+    }
+    return dest;
+}

--- a/src/memory/memory.h
+++ b/src/memory/memory.h
@@ -1,0 +1,10 @@
+#ifndef MEMORY_H
+#define MEMORY_H
+
+#include <stddef.h>
+
+void* memset(void* ptr, int c, size_t size);
+int memcmp(void* s1, void* s2, int count);
+void* memcpy(void* dest, void* src, int len);
+
+#endif

--- a/src/string/string.c
+++ b/src/string/string.c
@@ -1,0 +1,118 @@
+#include "string.h"
+
+char tolower(char s1)
+{
+    if (s1 >= 65 && s1 <= 90)
+    {
+        s1 += 32;
+    }
+
+    return s1;
+}
+
+int strlen(const char* ptr)
+{
+    int i = 0;
+    while(*ptr != 0)
+    {
+        i++;
+        ptr += 1;
+    }
+
+    return i;
+}
+
+int strnlen(const char* ptr, int max)
+{
+    int i = 0;
+    for (i = 0; i < max; i++)
+    {
+        if (ptr[i] == 0)
+            break;
+    }
+
+    return i;
+}
+
+int strnlen_terminator(const char* str, int max, char terminator)
+{
+    int i = 0;
+    for(i = 0; i < max; i++)
+    {
+        if (str[i] == '\0' || str[i] == terminator)
+            break;
+    }
+
+    return i;
+}
+
+int istrncmp(const char* s1, const char* s2, int n)
+{
+    unsigned char u1, u2;
+    while(n-- > 0)
+    {
+        u1 = (unsigned char)*s1++;
+        u2 = (unsigned char)*s2++;
+        if (u1 != u2 && tolower(u1) != tolower(u2))
+            return u1 - u2;
+        if (u1 == '\0')
+            return 0;
+    }
+
+    return 0;
+}
+int strncmp(const char* str1, const char* str2, int n)
+{
+    unsigned char u1, u2;
+
+    while(n-- > 0)
+    {
+        u1 = (unsigned char)*str1++;
+        u2 = (unsigned char)*str2++;
+        if (u1 != u2)
+            return u1 - u2;
+        if (u1 == '\0')
+            return 0;
+    }
+
+    return 0;
+}
+
+char* strcpy(char* dest, const char* src)
+{
+    char* res = dest;
+    while(*src != 0)
+    {
+        *dest = *src;
+        src += 1;
+        dest += 1;
+    }
+
+    *dest = 0x00;
+
+    return res;
+}
+
+char* strncpy(char* dest, const char* src, int count)
+{
+    int i = 0;
+    for (i = 0; i < count-1; i++)
+    {
+        if (src[i] == 0x00)
+            break;
+
+        dest[i] = src[i];
+    }
+
+    dest[i] = 0x00;
+    return dest;
+}
+
+bool isdigit(char c)
+{
+    return c >= 48 && c <= 57;
+}
+int tonumericdigit(char c)
+{
+    return c - 48;
+}

--- a/src/string/string.h
+++ b/src/string/string.h
@@ -1,0 +1,17 @@
+#ifndef STRING_H
+#define STRING_H
+
+#include <stdbool.h>
+
+int strlen(const char* ptr);
+int strnlen(const char* ptr, int max);
+bool isdigit(char c);
+int tonumericdigit(char c);
+char* strcpy(char* dest, const char* src);
+char* strncpy(char* dest, const char* src, int count);
+int strncmp(const char* str1, const char* str2, int n);
+int istrncmp(const char* s1, const char* s2, int n);
+int strnlen_terminator(const char* str, int max, char terminator);
+char tolower(char s1);
+
+#endif


### PR DESCRIPTION
## Summary
- add libc-like memory helpers (`memset`, `memcpy`, `memcmp`)
- add libc-like string helpers (`strlen`, `strcpy`, etc.)
- provide basic port IO helpers implemented in assembly
- compile new modules in Makefile
- update kernel to include new headers

## Testing
- `make clean`
- `make all` *(fails: `i686-elf-gcc` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68630fbe6b888324ac7d6d35b9300725