### PR TITLE
Add GDT structures and encoding helper

### DIFF
--- a/src/gdt/gdt.c
+++ b/src/gdt/gdt.c
@@ -1,0 +1,37 @@
+#include "gdt.h"
+#include "kernel.h"
+
+static void encode_gdt_entry(uint8_t* target, struct gdt_structured source)
+{
+    if ((source.limit > 65536) && ((source.limit & 0xFFF) != 0xFFF))
+    {
+        panic("encode_gdt_entry: Invalid argument\n");
+    }
+
+    target[6] = 0x40;
+    if (source.limit > 65536)
+    {
+        source.limit >>= 12;
+        target[6] = 0xC0;
+    }
+
+    target[0] = source.limit & 0xFF;
+    target[1] = (source.limit >> 8) & 0xFF;
+    target[6] |= (source.limit >> 16) & 0x0F;
+
+    target[2] = source.base & 0xFF;
+    target[3] = (source.base >> 8) & 0xFF;
+    target[4] = (source.base >> 16) & 0xFF;
+    target[7] = (source.base >> 24) & 0xFF;
+
+    target[5] = source.type;
+}
+
+void gdt_structured_to_gdt(struct gdt* gdt, struct gdt_structured* structured_gdt, int total_entries)
+{
+    for (int i = 0; i < total_entries; i++)
+    {
+        encode_gdt_entry((uint8_t*)&gdt[i], structured_gdt[i]);
+    }
+}
+

--- a/src/gdt/gdt.h
+++ b/src/gdt/gdt.h
@@ -1,0 +1,29 @@
+#ifndef GDT_H
+#define GDT_H
+
+#include <stdint.h>
+
+#define GDT_KERNEL_CODE_SELECTOR 0x08
+#define GDT_KERNEL_DATA_SELECTOR 0x10
+
+struct gdt
+{
+    uint16_t segment;
+    uint16_t base_first;
+    uint8_t base;
+    uint8_t access;
+    uint8_t high_flags;
+    uint8_t base_24_31_bits;
+} __attribute__((packed));
+
+struct gdt_structured
+{
+    uint32_t base;
+    uint32_t limit;
+    uint8_t type;
+};
+
+void gdt_load(struct gdt* gdt, int size);
+void gdt_structured_to_gdt(struct gdt* gdt, struct gdt_structured* structured_gdt, int total_entries);
+
+#endif


### PR DESCRIPTION
## Summary
- add packed GDT entry structures
- provide helper to encode `struct gdt_structured` into raw format
- expose constants for kernel code/data selectors

## Testing
- `make all` *(fails: `i686-elf-gcc: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_68633b00cf00832487a9803d011a031b