### PR TITLE
Add GDT loader routine

### DIFF
--- a/src/gdt/gdt.asm
+++ b/src/gdt/gdt.asm
@@ -1,0 +1,29 @@
+section .asm
+[BITS 32]
+
+global gdt_load
+
+CODE_SEG equ 0x08
+DATA_SEG equ 0x10
+
+; void gdt_load(struct gdt_descriptor* descriptor)
+gdt_load:
+    push ebp
+    mov ebp, esp
+
+    mov eax, [ebp+8] ; pointer to descriptor
+    lgdt [eax]
+
+    ; Reload segment registers
+    mov ax, DATA_SEG
+    mov ds, ax
+    mov es, ax
+    mov fs, ax
+    mov gs, ax
+    mov ss, ax
+
+    ; Far jump to reload code segment
+    jmp CODE_SEG:flush
+flush:
+    pop ebp
+    ret

--- a/src/gdt/gdt.h
+++ b/src/gdt/gdt.h
@@ -23,7 +23,13 @@ struct gdt_structured
     uint8_t type;
 };
 
-void gdt_load(struct gdt* gdt, int size);
+struct gdt_descriptor
+{
+    uint16_t size;
+    uint32_t address;
+} __attribute__((packed));
+
+void gdt_load(struct gdt_descriptor* descriptor);
 void gdt_structured_to_gdt(struct gdt* gdt, struct gdt_structured* structured_gdt, int total_entries);
 
 #endif


### PR DESCRIPTION
## Summary
- implement `gdt_load` assembly helper
- define `gdt_descriptor` and update `gdt_load` prototype

## Testing
- `make` *(fails: i686-elf-gcc missing)*

------
https://chatgpt.com/codex/tasks/task_e_68633c0bcdd88324b65ad452a96cbab9