### PR TITLE
Add TSS support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,11 @@
 FILES = ./build/kernel.asm.o \
-	./build/kernel.o \
-	./build/memory.o \
-	./build/string.o \
-	./build/io.o
+        ./build/kernel.o \
+        ./build/gdt.o \
+        ./build/gdt.asm.o \
+        ./build/tss.asm.o \
+        ./build/memory.o \
+        ./build/string.o \
+        ./build/io.o
 INCLUDES = -I./src
 FLAGS = -g -ffreestanding -falign-jumps -falign-functions -falign-labels -falign-loops -fstrength-reduce -fomit-frame-pointer -finline-functions -Wno-unused-function -fno-builtin -Werror -Wno-unused-label -Wno-cpp -Wno-unused-parameter -nostdlib -nostartfiles -nodefaultlibs -Wall -O0 -Iinc
 
@@ -24,6 +27,15 @@ all: ./bin/boot.bin ./bin/kernel.bin
 
 ./build/kernel.o: ./src/kernel.c
 	i686-elf-gcc $(INCLUDES) $(FLAGS) -std=gnu99 -c ./src/kernel.c -o ./build/kernel.o
+
+./build/gdt.o: ./src/gdt/gdt.c
+	i686-elf-gcc $(INCLUDES) $(FLAGS) -std=gnu99 -c ./src/gdt/gdt.c -o ./build/gdt.o
+
+./build/gdt.asm.o: ./src/gdt/gdt.asm
+	nasm -f elf -g ./src/gdt/gdt.asm -o ./build/gdt.asm.o
+
+./build/tss.asm.o: ./src/task/tss.asm
+	nasm -f elf -g ./src/task/tss.asm -o ./build/tss.asm.o
 
 ./build/memory.o: ./src/memory/memory.c
 	i686-elf-gcc $(INCLUDES) $(FLAGS) -std=gnu99 -c ./src/memory/memory.c -o ./build/memory.o

--- a/src/gdt/gdt.h
+++ b/src/gdt/gdt.h
@@ -5,6 +5,7 @@
 
 #define GDT_KERNEL_CODE_SELECTOR 0x08
 #define GDT_KERNEL_DATA_SELECTOR 0x10
+#define GDT_TSS_SELECTOR 0x18
 
 struct gdt
 {

--- a/src/kernel.h
+++ b/src/kernel.h
@@ -6,5 +6,7 @@
 
 
 void kernel_main();
+void print(const char* str);
+void panic(const char* msg);
 
 #endif

--- a/src/task/tss.asm
+++ b/src/task/tss.asm
@@ -1,0 +1,12 @@
+section .asm
+[BITS 32]
+
+global tss_load
+
+tss_load:
+    push ebp
+    mov ebp, esp
+    mov ax, [ebp+8]
+    ltr ax
+    pop ebp
+    ret

--- a/src/task/tss.h
+++ b/src/task/tss.h
@@ -1,0 +1,38 @@
+#ifndef TSS_H
+#define TSS_H
+
+#include <stdint.h>
+
+struct tss {
+    uint32_t link;
+    uint32_t esp0;
+    uint32_t ss0;
+    uint32_t esp1;
+    uint32_t ss1;
+    uint32_t esp2;
+    uint32_t ss2;
+    uint32_t cr3;
+    uint32_t eip;
+    uint32_t eflags;
+    uint32_t eax;
+    uint32_t ecx;
+    uint32_t edx;
+    uint32_t ebx;
+    uint32_t esp;
+    uint32_t ebp;
+    uint32_t esi;
+    uint32_t edi;
+    uint32_t es;
+    uint32_t cs;
+    uint32_t ss;
+    uint32_t ds;
+    uint32_t fs;
+    uint32_t gs;
+    uint32_t ldtr;
+    uint32_t iopb;
+    uint32_t ssp;
+} __attribute__((packed));
+
+void tss_load(uint16_t tss_segment);
+
+#endif


### PR DESCRIPTION
## Summary
- add Task State Segment structure and loader
- hook up GDT entry for the TSS
- expose print/panic helpers and update kernel to load the GDT/TSS
- compile new objects from task and gdt code

## Testing
- `./build-toolchain.sh` *(fails: command interrupted)*
- `make` *(fails: `i686-elf-gcc` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68633d00fc088324882f73247ee66bce