### PR TITLE
Add header paths for GDT and TSS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ FILES = ./build/kernel.asm.o \
         ./build/memory.o \
         ./build/string.o \
         ./build/io.o
-INCLUDES = -I./src
+INCLUDES = -I./src -I./src/gdt -I./src/task
 FLAGS = -g -ffreestanding -falign-jumps -falign-functions -falign-labels -falign-loops -fstrength-reduce -fomit-frame-pointer -finline-functions -Wno-unused-function -fno-builtin -Werror -Wno-unused-label -Wno-cpp -Wno-unused-parameter -nostdlib -nostartfiles -nodefaultlibs -Wall -O0 -Iinc
 
 all: ./bin/boot.bin ./bin/kernel.bin


### PR DESCRIPTION
## Summary
- update `INCLUDES` so GDT and TSS headers resolve when compiling

## Testing
- `./build-toolchain.sh` *(fails: 503 Service Unavailable)*
- `make all` *(fails: i686-elf-gcc not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863419f02708324a70272fab3cd6399