### PR TITLE
Add IDT subsystem

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,12 @@ FILES = ./build/kernel.asm.o \
         ./build/gdt.o \
         ./build/gdt.asm.o \
         ./build/tss.asm.o \
+        ./build/idt.o \
+        ./build/idt.asm.o \
         ./build/memory.o \
         ./build/string.o \
         ./build/io.o
-INCLUDES = -I./src -I./src/gdt -I./src/task
+INCLUDES = -I./src -I./src/gdt -I./src/task -I./src/idt
 FLAGS = -g -ffreestanding -falign-jumps -falign-functions -falign-labels -falign-loops -fstrength-reduce -fomit-frame-pointer -finline-functions -Wno-unused-function -fno-builtin -Werror -Wno-unused-label -Wno-cpp -Wno-unused-parameter -nostdlib -nostartfiles -nodefaultlibs -Wall -O0 -Iinc
 
 all: ./bin/boot.bin ./bin/kernel.bin
@@ -36,6 +38,12 @@ all: ./bin/boot.bin ./bin/kernel.bin
 
 ./build/tss.asm.o: ./src/task/tss.asm
 	nasm -f elf -g ./src/task/tss.asm -o ./build/tss.asm.o
+
+./build/idt.o: ./src/idt/idt.c
+	i686-elf-gcc $(INCLUDES) $(FLAGS) -std=gnu99 -c ./src/idt/idt.c -o ./build/idt.o
+
+./build/idt.asm.o: ./src/idt/idt.asm
+	nasm -f elf -g ./src/idt/idt.asm -o ./build/idt.asm.o
 
 ./build/memory.o: ./src/memory/memory.c
 	i686-elf-gcc $(INCLUDES) $(FLAGS) -std=gnu99 -c ./src/memory/memory.c -o ./build/memory.o

--- a/src/idt/idt.asm
+++ b/src/idt/idt.asm
@@ -1,0 +1,62 @@
+section .asm
+[BITS 32]
+
+extern interrupt_handler
+extern no_interrupt_handler
+
+global idt_load
+global no_interrupt
+global enable_interrupts
+global disable_interrupts
+global interrupt_pointer_table
+
+enable_interrupts:
+    sti
+    ret
+
+disable_interrupts:
+    cli
+    ret
+
+idt_load:
+    push ebp
+    mov ebp, esp
+    mov eax, [ebp+8]
+    lidt [eax]
+    pop ebp
+    ret
+
+no_interrupt:
+    pushad
+    call no_interrupt_handler
+    popad
+    iret
+
+%macro interrupt 1
+    global int%1
+    int%1:
+        pushad
+        push esp
+        push dword %1
+        call interrupt_handler
+        add esp, 8
+        popad
+        iret
+%endmacro
+
+%assign i 0
+%rep 256
+    interrupt i
+%assign i i+1
+%endrep
+
+%macro interrupt_array_entry 1
+    dd int%1
+%endmacro
+
+interrupt_pointer_table:
+%assign i 0
+%rep 256
+    interrupt_array_entry i
+%assign i i+1
+%endrep

--- a/src/idt/idt.c
+++ b/src/idt/idt.c
@@ -1,0 +1,64 @@
+#include "idt.h"
+#include "gdt/gdt.h"
+#include "io/io.h"
+#include "memory/memory.h"
+#include "kernel.h"
+
+#define IDT_TOTAL_DESCRIPTORS 256
+
+static struct idt_desc idt_descriptors[IDT_TOTAL_DESCRIPTORS];
+static struct idtr_desc idtr_descriptor;
+
+extern void* interrupt_pointer_table[IDT_TOTAL_DESCRIPTORS];
+extern void idt_load(struct idtr_desc* ptr);
+
+static INTERRUPT_CALLBACK_FUNCTION interrupt_callbacks[IDT_TOTAL_DESCRIPTORS];
+
+static void idt_set(int interrupt_no, void* address)
+{
+    struct idt_desc* desc = &idt_descriptors[interrupt_no];
+    desc->offset_1 = (uint32_t)address & 0xFFFF;
+    desc->selector = GDT_KERNEL_CODE_SELECTOR;
+    desc->zero = 0;
+    desc->type_attr = 0x8E;
+    desc->offset_2 = (uint32_t)address >> 16;
+}
+
+void no_interrupt_handler()
+{
+    outb(0x20, 0x20);
+}
+
+void interrupt_handler(int interrupt, struct interrupt_frame* frame)
+{
+    if (interrupt < IDT_TOTAL_DESCRIPTORS && interrupt_callbacks[interrupt])
+    {
+        interrupt_callbacks[interrupt](frame);
+    }
+    outb(0x20, 0x20);
+}
+
+void idt_init()
+{
+    memset(idt_descriptors, 0, sizeof(idt_descriptors));
+    idtr_descriptor.limit = sizeof(idt_descriptors) - 1;
+    idtr_descriptor.base = (uint32_t)idt_descriptors;
+
+    for (int i = 0; i < IDT_TOTAL_DESCRIPTORS; i++)
+    {
+        idt_set(i, interrupt_pointer_table[i]);
+    }
+
+    idt_load(&idtr_descriptor);
+}
+
+int idt_register_interrupt_callback(int interrupt, INTERRUPT_CALLBACK_FUNCTION callback)
+{
+    if (interrupt < 0 || interrupt >= IDT_TOTAL_DESCRIPTORS)
+    {
+        return -1;
+    }
+
+    interrupt_callbacks[interrupt] = callback;
+    return 0;
+}

--- a/src/idt/idt.h
+++ b/src/idt/idt.h
@@ -1,0 +1,47 @@
+#ifndef IDT_H
+#define IDT_H
+
+#include <stdint.h>
+
+struct interrupt_frame;
+
+typedef void(*INTERRUPT_CALLBACK_FUNCTION)(struct interrupt_frame* frame);
+
+struct idt_desc
+{
+    uint16_t offset_1;
+    uint16_t selector;
+    uint8_t zero;
+    uint8_t type_attr;
+    uint16_t offset_2;
+} __attribute__((packed));
+
+struct idtr_desc
+{
+    uint16_t limit;
+    uint32_t base;
+} __attribute__((packed));
+
+struct interrupt_frame
+{
+    uint32_t edi;
+    uint32_t esi;
+    uint32_t ebp;
+    uint32_t reserved;
+    uint32_t ebx;
+    uint32_t edx;
+    uint32_t ecx;
+    uint32_t eax;
+    uint32_t ip;
+    uint32_t cs;
+    uint32_t flags;
+    uint32_t esp;
+    uint32_t ss;
+} __attribute__((packed));
+
+void idt_init();
+void enable_interrupts();
+void disable_interrupts();
+int idt_register_interrupt_callback(int interrupt, INTERRUPT_CALLBACK_FUNCTION interrupt_callback);
+
+#endif

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -3,6 +3,7 @@
 #include "memory/memory.h"
 #include "gdt/gdt.h"
 #include "task/tss.h"
+#include "idt/idt.h"
 #include <stddef.h>
 #include <stdint.h>
 
@@ -89,10 +90,14 @@ void kernel_main()
     desc.address = (uint32_t)gdt_real;
     gdt_load(&desc);
 
+    idt_init();
+
     memset(&tss, 0x00, sizeof(tss));
     tss.esp0 = 0x600000;
     tss.ss0 = GDT_KERNEL_DATA_SELECTOR;
     tss_load(GDT_TSS_SELECTOR);
+
+    enable_interrupts();
 
     print("Hello world!\n");
 }


### PR DESCRIPTION
## Summary
- introduce interrupt descriptor table implementation
- provide assembly helpers to load and enable the IDT
- hook initialization and interrupt enabling in the kernel
- extend build rules for new sources

## Testing
- `bash build.sh` *(fails: i686-elf-gcc missing)*

------
https://chatgpt.com/codex/tasks/task_e_68634461d75c8324a3b851bea589de58