### PR TITLE
Fix unhandled interrupts

### DIFF
--- a/src/idt/idt.c
+++ b/src/idt/idt.c
@@ -14,6 +14,12 @@ extern void idt_load(struct idtr_desc* ptr);
 
 static INTERRUPT_CALLBACK_FUNCTION interrupt_callbacks[IDT_TOTAL_DESCRIPTORS];
 
+void interrupt_ignore(struct interrupt_frame* frame)
+{
+    (void)frame;
+    outb(0x20, 0x20);
+}
+
 static void idt_set(int interrupt_no, void* address)
 {
     struct idt_desc* desc = &idt_descriptors[interrupt_no];

--- a/src/idt/idt.h
+++ b/src/idt/idt.h
@@ -43,5 +43,6 @@ void idt_init();
 void enable_interrupts();
 void disable_interrupts();
 int idt_register_interrupt_callback(int interrupt, INTERRUPT_CALLBACK_FUNCTION interrupt_callback);
+void interrupt_ignore(struct interrupt_frame* frame);
 
 #endif

--- a/src/kernel.asm
+++ b/src/kernel.asm
@@ -21,6 +21,16 @@ _start:
     or al, 2
     out 0x92, al
 
+    ; Remap the master PIC so IRQs start at 0x20
+    mov al, 00010001b
+    out 0x20, al
+    mov al, 0x20
+    out 0x21, al
+    mov al, 0x04
+    out 0x21, al
+    mov al, 00000001b
+    out 0x21, al
+
     call kernel_main
 
     jmp $

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -101,6 +101,9 @@ void kernel_main()
     // With the GDT and TSS active we can setup the IDT
     idt_init();
 
+    // Ignore spurious timer interrupts until proper handlers exist
+    idt_register_interrupt_callback(0x20, interrupt_ignore);
+
     enable_interrupts();
 
     print("Hello world!\n");


### PR DESCRIPTION
## Summary
- remap PIC to avoid CPU exception vectors
- ignore spurious timer interrupt until handlers are added

## Testing
- `make clean`
- `make all` *(fails: i686-elf-gcc: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6863644591b88324b580e21dc65c4f33