### PR TITLE
Add heap section and init heap early

### DIFF
--- a/src/kernel.c
+++ b/src/kernel.c
@@ -4,6 +4,7 @@
 #include "gdt/gdt.h"
 #include "task/tss.h"
 #include "idt/idt.h"
+#include "memory/heap/kheap.h"
 #include <stddef.h>
 #include <stdint.h>
 
@@ -92,6 +93,9 @@ void kernel_main()
     desc.size = sizeof(gdt_real) - 1;
     desc.address = (uint32_t)gdt_real;
     gdt_load(&desc);
+
+    // Initialize the kernel heap before paging
+    kheap_init();
 
     memset(&tss, 0x00, sizeof(tss));
     tss.esp0 = 0x600000;

--- a/src/linker.ld
+++ b/src/linker.ld
@@ -24,6 +24,12 @@ SECTIONS
         *(.bss)
     }
 
+    /* Reserve space for the kernel heap */
+    .heap : ALIGN(4096)
+    {
+        . = . + 104857600; /* 100MB */
+    }
+
     .asm : ALIGN(4096)
     {
         *(.asm)


### PR DESCRIPTION
## Summary
- reserve heap memory in linker script
- initialize heap early in `kernel_main`

## Testing
- `make all` *(fails: `i686-elf-gcc` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68636809795883249e483e6e78b1e7fb