### PR TITLE
Setup paging in kernel_main

### DIFF
--- a/src/kernel.c
+++ b/src/kernel.c
@@ -5,6 +5,7 @@
 #include "task/tss.h"
 #include "idt/idt.h"
 #include "memory/heap/kheap.h"
+#include "memory/paging/paging.h"
 #include <stddef.h>
 #include <stdint.h>
 
@@ -107,6 +108,12 @@ void kernel_main()
 
     // Ignore spurious timer interrupts until proper handlers exist
     idt_register_interrupt_callback(0x20, interrupt_ignore);
+
+    struct paging_4gb_chunk* kernel_chunk =
+        paging_new_4gb(PAGING_IS_WRITEABLE | PAGING_IS_PRESENT |
+                       PAGING_ACCESS_FROM_ALL);
+    paging_switch(kernel_chunk);
+    enable_paging();
 
     enable_interrupts();
 


### PR DESCRIPTION
## Summary
- include paging helper headers in the kernel
- build and switch to a 4GB paging directory
- enable paging before enabling interrupts

## Testing
- `bash ./build.sh` *(fails: `i686-elf-gcc` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863696f9d8083248edf0887360aa16f