### PR TITLE
Add paging and heap sources to kernel build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,25 @@
 FILES = ./build/kernel.asm.o \
-        ./build/kernel.o \
-        ./build/gdt.o \
-        ./build/gdt.asm.o \
-        ./build/tss.asm.o \
-        ./build/idt.o \
-        ./build/idt.asm.o \
-        ./build/memory.o \
-        ./build/string.o \
-        ./build/io.o
+	./build/kernel.o \
+	./build/gdt.o \
+	./build/gdt.asm.o \
+	./build/tss.asm.o \
+	./build/idt.o \
+	./build/idt.asm.o \
+	./build/memory.o \
+	./build/string.o \
+	./build/io.o \
+	./build/memory/heap/heap.o \
+	./build/memory/heap/kheap.o \
+	./build/memory/paging/paging.o \
+	./build/memory/paging/paging.asm.o
 INCLUDES = -I./src -I./src/gdt -I./src/task -I./src/idt
+BUILD_DIRS = ./bin ./build/memory/heap ./build/memory/paging
 FLAGS = -g -ffreestanding -falign-jumps -falign-functions -falign-labels -falign-loops -fstrength-reduce -fomit-frame-pointer -finline-functions -Wno-unused-function -fno-builtin -Werror -Wno-unused-label -Wno-cpp -Wno-unused-parameter -nostdlib -nostartfiles -nodefaultlibs -Wall -O0 -Iinc
 
-all: ./bin/boot.bin ./bin/kernel.bin
+dirs:
+	mkdir -p $(BUILD_DIRS)
+
+all: dirs ./bin/boot.bin ./bin/kernel.bin
 	rm -rf ./bin/os.bin
 	dd if=./bin/boot.bin >> ./bin/os.bin
 	dd if=./bin/kernel.bin >> ./bin/os.bin
@@ -53,6 +61,18 @@ all: ./bin/boot.bin ./bin/kernel.bin
 
 ./build/io.o: ./src/io/io.asm
 	nasm -f elf -g ./src/io/io.asm -o ./build/io.o
+
+./build/memory/heap/heap.o: ./src/memory/heap/heap.c
+	i686-elf-gcc $(INCLUDES) -I./src/memory/heap $(FLAGS) -std=gnu99 -c ./src/memory/heap/heap.c -o ./build/memory/heap/heap.o
+
+./build/memory/heap/kheap.o: ./src/memory/heap/kheap.c
+	i686-elf-gcc $(INCLUDES) -I./src/memory/heap $(FLAGS) -std=gnu99 -c ./src/memory/heap/kheap.c -o ./build/memory/heap/kheap.o
+
+./build/memory/paging/paging.o: ./src/memory/paging/paging.c
+	i686-elf-gcc $(INCLUDES) -I./src/memory/paging $(FLAGS) -std=gnu99 -c ./src/memory/paging/paging.c -o ./build/memory/paging/paging.o
+
+./build/memory/paging/paging.asm.o: ./src/memory/paging/paging.asm
+	nasm -f elf -g ./src/memory/paging/paging.asm -o ./build/memory/paging/paging.asm.o
 
 clean:
 	rm -rf ./bin/boot.bin


### PR DESCRIPTION
## Summary
- compile and link paging and heap sources
- ensure build directories exist before compiling

## Testing
- `./build-toolchain.sh` *(fails: command was aborted)*
- `make all` *(fails: `i686-elf-gcc` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68636a5abf888324b901b01cdbd0f723