### PR TITLE
Remove heap section and mark bss as noload

### DIFF
--- a/src/linker.ld
+++ b/src/linker.ld
@@ -18,17 +18,12 @@ SECTIONS
         *(.data)
     }
 
-    .bss : ALIGN(4096)
+    .bss (NOLOAD) : ALIGN(4096)
     {
         *(COMMON)
         *(.bss)
     }
 
-    /* Reserve space for the kernel heap */
-    .heap : ALIGN(4096)
-    {
-        . = . + 104857600; /* 100MB */
-    }
 
     .asm : ALIGN(4096)
     {


### PR DESCRIPTION
## Summary
- shrink kernel binary by removing the heap section from `linker.ld`
- mark the bss segment as `NOLOAD` so it isn't written to the raw binary

## Testing
- `bash build.sh`

------
https://chatgpt.com/codex/tasks/task_e_6863ecf8a3608324a43123d87fadd769