### PR TITLE
Enable A20 in bootloader

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ FILES = ./build/kernel.asm.o \
 	./build/memory/paging/paging.asm.o
 INCLUDES = -I./src -I./src/gdt -I./src/task -I./src/idt
 BUILD_DIRS = ./bin ./build/memory/heap ./build/memory/paging
-FLAGS = -g -ffreestanding -falign-jumps -falign-functions -falign-labels -falign-loops -fstrength-reduce -fomit-frame-pointer -finline-functions -Wno-unused-function -fno-builtin -Werror -Wno-unused-label -Wno-cpp -Wno-unused-parameter -nostdlib -nostartfiles -nodefaultlibs -Wall -O0 -Iinc
+FLAGS = -g -ffreestanding -falign-jumps -falign-functions -falign-labels -falign-loops -fstrength-reduce -fomit-frame-pointer -finline-functions -Wno-unused-function -fno-builtin -Werror -Wno-unused-label -Wno-cpp -Wno-unused-parameter -nostdlib -nostartfiles -nodefaultlibs -Wall -O0 -Iinc -fno-pie -no-pie
 
 dirs:
 	mkdir -p $(BUILD_DIRS)

--- a/src/boot/boot.asm
+++ b/src/boot/boot.asm
@@ -68,6 +68,11 @@ load32:
     mov fs, ax
     mov gs, ax
     mov ss, ax
+
+    ; Enable the A20 line
+    in al, 0x92
+    or al, 2
+    out 0x92, al
     mov eax, 1
     mov ecx, 100
     mov edi, 0x0100000


### PR DESCRIPTION
## Summary
- enable A20 line after switching to protected mode
- disable PIE when building kernel so cross-compilation works

## Testing
- `make clean`
- `make all`
- `timeout 5 qemu-system-i386 -drive format=raw,file=./bin/os.bin -display none`

------
https://chatgpt.com/codex/tasks/task_e_6863f4921d58832488b2a63648e3081e