### PR TITLE
Fix BSS in linker script

### DIFF
--- a/src/linker.ld
+++ b/src/linker.ld
@@ -18,7 +18,7 @@ SECTIONS
         *(.data)
     }
 
-    .bss (NOLOAD) : ALIGN(4096)
+    .bss : ALIGN(4096)
     {
         *(COMMON)
         *(.bss)


### PR DESCRIPTION
## Summary
- remove the `NOLOAD` attribute from the `.bss` section of `linker.ld`

## Testing
- `make all` *(fails: `i686-elf-gcc` missing)*
- `make run` *(fails: `qemu-system-i386` missing)*

------
https://chatgpt.com/codex/tasks/task_e_6863fd3a36e08324b70198bbb2a201cc