### PR TITLE
Add PS/2 keyboard driver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,12 +8,14 @@ FILES = ./build/kernel.asm.o \
 	./build/memory.o \
 	./build/string.o \
 	./build/io.o \
+        ./build/keyboard/keyboard.o \
+        ./build/keyboard/classic.o \
 	./build/memory/heap/heap.o \
 	./build/memory/heap/kheap.o \
 	./build/memory/paging/paging.o \
 	./build/memory/paging/paging.asm.o
 INCLUDES = -I./src -I./src/gdt -I./src/task -I./src/idt
-BUILD_DIRS = ./bin ./build/memory/heap ./build/memory/paging
+BUILD_DIRS = ./bin ./build/memory/heap ./build/memory/paging ./build/keyboard
 FLAGS = -g -ffreestanding -falign-jumps -falign-functions -falign-labels -falign-loops -fstrength-reduce -fomit-frame-pointer -finline-functions -Wno-unused-function -fno-builtin -Werror -Wno-unused-label -Wno-cpp -Wno-unused-parameter -nostdlib -nostartfiles -nodefaultlibs -Wall -O0 -Iinc -fno-pie -no-pie
 
 dirs:
@@ -61,6 +63,12 @@ all: dirs ./bin/boot.bin ./bin/kernel.bin
 
 ./build/io.o: ./src/io/io.asm
 	nasm -f elf -g ./src/io/io.asm -o ./build/io.o
+
+./build/keyboard/keyboard.o: ./src/keyboard/keyboard.c
+	i686-elf-gcc $(INCLUDES) $(FLAGS) -std=gnu99 -c ./src/keyboard/keyboard.c -o ./build/keyboard/keyboard.o
+
+./build/keyboard/classic.o: ./src/keyboard/classic.c
+	i686-elf-gcc $(INCLUDES) $(FLAGS) -std=gnu99 -c ./src/keyboard/classic.c -o ./build/keyboard/classic.o
 
 ./build/memory/heap/heap.o: ./src/memory/heap/heap.c
 	i686-elf-gcc $(INCLUDES) -I./src/memory/heap $(FLAGS) -std=gnu99 -c ./src/memory/heap/heap.c -o ./build/memory/heap/heap.o

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -5,6 +5,7 @@
 #include "task/tss.h"
 #include "idt/idt.h"
 #include "memory/heap/kheap.h"
+#include "keyboard/keyboard.h"
 #include "memory/paging/paging.h"
 #include <stddef.h>
 #include <stdint.h>
@@ -114,6 +115,8 @@ void kernel_main()
     // Ignore spurious timer interrupts until proper handlers exist
     idt_register_interrupt_callback(0x20, interrupt_ignore);
 
+    keyboard_init();
+    print("Keyboard initialized.\n");
     struct paging_4gb_chunk* kernel_chunk =
         paging_new_4gb(PAGING_IS_WRITEABLE | PAGING_IS_PRESENT |
                        PAGING_ACCESS_FROM_ALL);

--- a/src/keyboard/classic.c
+++ b/src/keyboard/classic.c
@@ -1,0 +1,88 @@
+#include "classic.h"
+#include "keyboard.h"
+#include "io/io.h"
+#include "idt/idt.h"
+#include <stdint.h>
+#include <stddef.h>
+
+#define CLASSIC_KEYBOARD_CAPSLOCK 0x3A
+
+int classic_keyboard_init();
+
+static uint8_t keyboard_scan_set_one[] = {
+    0x00, 0x1B, '1', '2', '3', '4', '5',
+    '6', '7', '8', '9', '0', '-', '=',
+    0x08, '\t', 'Q', 'W', 'E', 'R', 'T',
+    'Y', 'U', 'I', 'O', 'P', '[', ']',
+    0x0d, 0x00, 'A', 'S', 'D', 'F', 'G',
+    'H', 'J', 'K', 'L', ';', '\'', '`',
+    0x00, '\\', 'Z', 'X', 'C', 'V', 'B',
+    'N', 'M', ',', '.', '/', 0x00, '*',
+    0x00, 0x20, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, '7', '8', '9', '-', '4', '5',
+    '6', '+', '1', '2', '3', '0', '.'
+};
+
+static struct keyboard classic_keyboard = {
+    .name = {"Classic"},
+    .init = classic_keyboard_init
+};
+
+void classic_keyboard_handle_interrupt();
+
+int classic_keyboard_init()
+{
+    idt_register_interrupt_callback(ISR_KEYBOARD_INTERRUPT, classic_keyboard_handle_interrupt);
+    keyboard_set_capslock(&classic_keyboard, KEYBOARD_CAPS_LOCK_OFF);
+    outb(PS2_PORT, PS2_COMMAND_ENABLE_FIRST_PORT);
+    return 0;
+}
+
+uint8_t classic_keyboard_scancode_to_char(uint8_t scancode)
+{
+    size_t size_of_keyboard_set_one = sizeof(keyboard_scan_set_one) / sizeof(uint8_t);
+    if (scancode > size_of_keyboard_set_one)
+    {
+        return 0;
+    }
+
+    char c = keyboard_scan_set_one[scancode];
+    if (keyboard_get_capslock(&classic_keyboard) == KEYBOARD_CAPS_LOCK_OFF)
+    {
+        if (c >= 'A' && c <= 'Z')
+        {
+            c += 32;
+        }
+    }
+    return c;
+}
+
+void classic_keyboard_handle_interrupt()
+{
+    uint8_t scancode = insb(KEYBOARD_INPUT_PORT);
+    insb(KEYBOARD_INPUT_PORT);
+
+    if(scancode & CLASSIC_KEYBOARD_KEY_RELEASED)
+    {
+        return;
+    }
+
+    if (scancode == CLASSIC_KEYBOARD_CAPSLOCK)
+    {
+        KEYBOARD_CAPS_LOCK_STATE old_state = keyboard_get_capslock(&classic_keyboard);
+        keyboard_set_capslock(&classic_keyboard, old_state == KEYBOARD_CAPS_LOCK_ON ? KEYBOARD_CAPS_LOCK_OFF : KEYBOARD_CAPS_LOCK_ON);
+        return;
+    }
+
+    uint8_t c = classic_keyboard_scancode_to_char(scancode);
+    if (c != 0)
+    {
+        keyboard_push(c);
+    }
+}
+
+struct keyboard* classic_init()
+{
+    return &classic_keyboard;
+}

--- a/src/keyboard/classic.h
+++ b/src/keyboard/classic.h
@@ -1,0 +1,13 @@
+#ifndef CLASSIC_KEYBOARD_H
+#define CLASSIC_KEYBOARD_H
+
+#define PS2_PORT 0x64
+#define PS2_COMMAND_ENABLE_FIRST_PORT 0xAE
+
+#define CLASSIC_KEYBOARD_KEY_RELEASED 0x80
+#define ISR_KEYBOARD_INTERRUPT 0x21
+#define KEYBOARD_INPUT_PORT 0x60
+
+struct keyboard* classic_init();
+
+#endif

--- a/src/keyboard/keyboard.c
+++ b/src/keyboard/keyboard.c
@@ -1,0 +1,89 @@
+#include "keyboard.h"
+#include "status.h"
+#include "classic.h"
+
+static struct keyboard* keyboard_list_head = 0;
+static struct keyboard* keyboard_list_last = 0;
+
+struct keyboard_buffer
+{
+    char buffer[VANA_KEYBOARD_BUFFER_SIZE];
+    int head;
+    int tail;
+};
+
+static struct keyboard_buffer kbuffer;
+
+void keyboard_init()
+{
+    keyboard_insert(classic_init());
+}
+
+int keyboard_insert(struct keyboard* keyboard)
+{
+    int res = 0;
+    if (!keyboard || !keyboard->init)
+    {
+        return -EINVARG;
+    }
+
+    if (keyboard_list_last)
+    {
+        keyboard_list_last->next = keyboard;
+        keyboard_list_last = keyboard;
+    }
+    else
+    {
+        keyboard_list_head = keyboard;
+        keyboard_list_last = keyboard;
+    }
+
+    res = keyboard->init();
+    return res;
+}
+
+static int keyboard_get_tail_index()
+{
+    return kbuffer.tail % VANA_KEYBOARD_BUFFER_SIZE;
+}
+
+void keyboard_backspace()
+{
+    if (kbuffer.tail == 0)
+        return;
+    kbuffer.tail -= 1;
+    int real_index = keyboard_get_tail_index();
+    kbuffer.buffer[real_index] = 0x00;
+}
+
+void keyboard_set_capslock(struct keyboard* keyboard, KEYBOARD_CAPS_LOCK_STATE state)
+{
+    keyboard->capslock_state = state;
+}
+
+KEYBOARD_CAPS_LOCK_STATE keyboard_get_capslock(struct keyboard* keyboard)
+{
+    return keyboard->capslock_state;
+}
+
+void keyboard_push(char c)
+{
+    if (c == 0)
+        return;
+    int real_index = keyboard_get_tail_index();
+    kbuffer.buffer[real_index] = c;
+    kbuffer.tail++;
+}
+
+char keyboard_pop()
+{
+    int real_index = kbuffer.head % VANA_KEYBOARD_BUFFER_SIZE;
+    char c = kbuffer.buffer[real_index];
+    if (c == 0x00)
+    {
+        return 0;
+    }
+    kbuffer.buffer[real_index] = 0x00;
+    kbuffer.head++;
+    return c;
+}

--- a/src/keyboard/keyboard.h
+++ b/src/keyboard/keyboard.h
@@ -1,0 +1,30 @@
+#ifndef KEYBOARD_H
+#define KEYBOARD_H
+
+#include <stdint.h>
+#include "config.h"
+
+#define KEYBOARD_CAPS_LOCK_ON 1
+#define KEYBOARD_CAPS_LOCK_OFF 0
+
+typedef int KEYBOARD_CAPS_LOCK_STATE;
+
+typedef int (*KEYBOARD_INIT_FUNCTION)();
+
+struct keyboard
+{
+    KEYBOARD_INIT_FUNCTION init;
+    char name[20];
+    KEYBOARD_CAPS_LOCK_STATE capslock_state;
+    struct keyboard* next;
+};
+
+void keyboard_init();
+void keyboard_backspace();
+void keyboard_push(char c);
+char keyboard_pop();
+int keyboard_insert(struct keyboard* keyboard);
+void keyboard_set_capslock(struct keyboard* keyboard, KEYBOARD_CAPS_LOCK_STATE state);
+KEYBOARD_CAPS_LOCK_STATE keyboard_get_capslock(struct keyboard* keyboard);
+
+#endif


### PR DESCRIPTION
## Summary
- introduce generic keyboard buffer handling
- implement classic PS/2 keyboard driver
- compile keyboard sources and initialise the keyboard in the kernel

## Testing
- `make all` *(fails: i686-elf-gcc missing)*

------
https://chatgpt.com/codex/tasks/task_e_686400b529188324ad49cc3130a98c5a