### PR TITLE
Initialize disk in kernel main

### DIFF
--- a/src/kernel.c
+++ b/src/kernel.c
@@ -7,6 +7,8 @@
 #include "memory/heap/kheap.h"
 #include "keyboard/keyboard.h"
 #include "memory/paging/paging.h"
+#include "disk/disk.h"
+#include "disk/streamer.h"
 #include <stddef.h>
 #include <stdint.h>
 
@@ -114,6 +116,12 @@ void kernel_main()
 
     // Ignore spurious timer interrupts until proper handlers exist
     idt_register_interrupt_callback(0x20, interrupt_ignore);
+
+    disk_search_and_init();
+    struct disk_stream* default_stream = diskstreamer_new(0);
+    if (default_stream)
+        diskstreamer_close(default_stream);
+    print("Disk initialized.\n");
 
     keyboard_init();
     print("Keyboard initialized.\n");


### PR DESCRIPTION
## Summary
- add disk includes to `kernel.c`
- initialize disks and create a default stream during startup

## Testing
- `make all` *(fails: `i686-elf-gcc` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686409b4ec5c832497e115bb7bb627ea