### PR TITLE
Include config header in file parsers

### DIFF
--- a/src/fs/fat/fat16.c
+++ b/src/fs/fat/fat16.c
@@ -1,4 +1,5 @@
 #include "fat16.h"
+#include "config.h"
 #include "string/string.h"
 #include "disk/disk.h"
 #include "disk/streamer.h"

--- a/src/fs/pparser.c
+++ b/src/fs/pparser.c
@@ -1,4 +1,5 @@
 #include "pparser.h"
+#include "config.h"
 #include "kernel.h"
 #include "string/string.h"
 #include "memory/heap/kheap.h"


### PR DESCRIPTION
## Summary
- include `config.h` in the path parser so `VANA_MAX_PATH` is available
- include `config.h` in the FAT16 module for the same reason

## Testing
- `nasm -v`


------
https://chatgpt.com/codex/tasks/task_e_686432f91420832493f5d7f2894a96ba