### PR TITLE
Register IRQ15 ignore handler

### DIFF
--- a/src/idt/idt.c
+++ b/src/idt/idt.c
@@ -79,6 +79,7 @@ void idt_init()
         idt_register_interrupt_callback(i, idt_handle_exception);
     }
     idt_register_interrupt_callback(0x27, interrupt_ignore);
+    idt_register_interrupt_callback(0x2F, interrupt_ignore);
 }
 
 int idt_register_interrupt_callback(int interrupt, INTERRUPT_CALLBACK_FUNCTION callback)


### PR DESCRIPTION
## Summary
- register an interrupt ignore handler for IRQ15

## Testing
- `bash build.sh` *(fails: `i686-elf-gcc: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_6864481f75148324b15d5eba95e1ef21