### PR TITLE
Improve interrupt panic message

### DIFF
--- a/src/idt/idt.c
+++ b/src/idt/idt.c
@@ -3,6 +3,7 @@
 #include "io/io.h"
 #include "memory/memory.h"
 #include "kernel.h"
+#include "string/string.h"
 
 #define IDT_TOTAL_DESCRIPTORS 256
 
@@ -52,7 +53,12 @@ void interrupt_handler(int interrupt, struct interrupt_frame* frame)
         }
         else
         {
-            panic("Unhandled interrupt\n");
+            char buf[32];
+            int_to_string(interrupt, buf);
+            print("Unhandled interrupt ");
+            print(buf);
+            print("\n");
+            panic("");
         }
     }
     outb(0x20, 0x20);

--- a/src/string/string.c
+++ b/src/string/string.c
@@ -116,3 +116,30 @@ int tonumericdigit(char c)
 {
     return c - 48;
 }
+
+void int_to_string(int value, char* out)
+{
+    char temp[32];
+    int i = 0;
+
+    if (value == 0)
+    {
+        out[0] = '0';
+        out[1] = '\0';
+        return;
+    }
+
+    while (value > 0)
+    {
+        int digit = value % 10;
+        temp[i++] = (char)(digit + '0');
+        value /= 10;
+    }
+
+    int j = 0;
+    while (i > 0)
+    {
+        out[j++] = temp[--i];
+    }
+    out[j] = '\0';
+}

--- a/src/string/string.h
+++ b/src/string/string.h
@@ -13,5 +13,6 @@ int strncmp(const char* str1, const char* str2, int n);
 int istrncmp(const char* s1, const char* s2, int n);
 int strnlen_terminator(const char* str, int max, char terminator);
 char tolower(char s1);
+void int_to_string(int value, char* out);
 
 #endif


### PR DESCRIPTION
## Summary
- show interrupt vector before panicking on unknown interrupt
- expose new `int_to_string` helper in string library

## Testing
- `./build.sh`
- `make run` *(fails: gtk initialization failed)*

------
https://chatgpt.com/codex/tasks/task_e_6864491b7a7c832480af39177c7386f5