### PR TITLE
Add PIC slave EOI handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ FILES = ./build/kernel.asm.o \
         ./build/idt.asm.o \
         ./build/memory.o \
         ./build/string.o \
+        ./build/pic.o \
         ./build/io.o \
         $(DISK_OBJS) \
         $(KEYBOARD_OBJS) \
@@ -69,6 +70,9 @@ all: dirs ./bin/boot.bin ./bin/kernel.bin
 
 ./build/string.o: ./src/string/string.c
 	i686-elf-gcc $(INCLUDES) $(FLAGS) -std=gnu99 -c ./src/string/string.c -o ./build/string.o
+
+./build/pic.o: ./src/pic/pic.c
+	i686-elf-gcc $(INCLUDES) $(FLAGS) -std=gnu99 -c ./src/pic/pic.c -o ./build/pic.o
 
 ./build/io.o: ./src/io/io.asm
 	nasm -f elf -g ./src/io/io.asm -o ./build/io.o

--- a/src/idt/idt.c
+++ b/src/idt/idt.c
@@ -1,6 +1,7 @@
 #include "idt.h"
 #include "gdt/gdt.h"
 #include "io/io.h"
+#include "pic/pic.h"
 #include "memory/memory.h"
 #include "kernel.h"
 #include "string/string.h"
@@ -18,14 +19,12 @@ static INTERRUPT_CALLBACK_FUNCTION interrupt_callbacks[IDT_TOTAL_DESCRIPTORS];
 void interrupt_ignore(struct interrupt_frame* frame)
 {
     (void)frame;
-    outb(0x20, 0x20);
 }
 
 static void idt_handle_exception(struct interrupt_frame* frame)
 {
     (void)frame;
     print("CPU exception\n");
-    outb(0x20, 0x20);
 }
 
 static void idt_set(int interrupt_no, void* address)
@@ -40,7 +39,6 @@ static void idt_set(int interrupt_no, void* address)
 
 void no_interrupt_handler()
 {
-    outb(0x20, 0x20);
 }
 
 void interrupt_handler(int interrupt, struct interrupt_frame* frame)
@@ -61,7 +59,11 @@ void interrupt_handler(int interrupt, struct interrupt_frame* frame)
             panic("");
         }
     }
-    outb(0x20, 0x20);
+
+    if (interrupt >= 0x20 && interrupt <= 0x2F)
+    {
+        pic_send_eoi(interrupt - 0x20);
+    }
 }
 
 void idt_init()

--- a/src/keyboard/keyboard.c
+++ b/src/keyboard/keyboard.c
@@ -59,7 +59,6 @@ static void keyboard_irq_handler(struct interrupt_frame* frame)
     uint8_t scancode = insb(KEYBOARD_INPUT_PORT);
     insb(KEYBOARD_INPUT_PORT);
     keyboard_push((char)scancode);
-    outb(0x20, 0x20);
 }
 
 void keyboard_backspace()

--- a/src/pic/pic.c
+++ b/src/pic/pic.c
@@ -1,0 +1,11 @@
+#include "pic.h"
+#include "io/io.h"
+
+void pic_send_eoi(int irq)
+{
+    if (irq >= 8)
+    {
+        outb(PIC2_COMMAND, PIC_EOI);
+    }
+    outb(PIC1_COMMAND, PIC_EOI);
+}

--- a/src/pic/pic.h
+++ b/src/pic/pic.h
@@ -1,0 +1,12 @@
+#ifndef PIC_H
+#define PIC_H
+
+#define PIC1_COMMAND 0x20
+#define PIC1_DATA 0x21
+#define PIC2_COMMAND 0xA0
+#define PIC2_DATA 0xA1
+#define PIC_EOI 0x20
+
+void pic_send_eoi(int irq);
+
+#endif


### PR DESCRIPTION
## Summary
- introduce `pic_send_eoi()` and constants
- send EOI for slave interrupts in `interrupt_handler`
- remove inline EOI from keyboard IRQ
- compile new PIC module via Makefile

## Testing
- `make` *(fails: `i686-elf-gcc: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_68644d437cdc8324b34c691d8c786756