### PR TITLE
Handle IDE interrupt

### DIFF
--- a/src/idt/idt.c
+++ b/src/idt/idt.c
@@ -89,6 +89,7 @@ void idt_init()
         idt_register_interrupt_callback(i, idt_handle_exception);
     }
     idt_register_interrupt_callback(0x27, interrupt_ignore);
+    idt_register_interrupt_callback(0x2E, interrupt_ignore); // IDE (IRQ14)
     idt_register_interrupt_callback(0x2F, interrupt_ignore);
 }
 


### PR DESCRIPTION
## Summary
- ignore IDE interrupt 0x2E during IDT initialization

## Testing
- `bash build.sh`

------
https://chatgpt.com/codex/tasks/task_e_6864504c954883249a30c81d01c0956f