### PR TITLE
Mask all IRQs after PIC remap

### DIFF
--- a/src/kernel.asm
+++ b/src/kernel.asm
@@ -36,9 +36,9 @@ _start:
     mov al, 0x01
     out 0x21, al
     out 0xA1, al
-    mov al, 0x0
-    out 0x21, al
-    out 0xA1, al
+    mov al, 0xFF
+    out 0x21, al        ; mask all master IRQs
+    out 0xA1, al        ; mask all slave IRQs
 
     call kernel_main
 


### PR DESCRIPTION
## Summary
- keep interrupts disabled until the kernel unmasks them

## Testing
- `make all` *(fails: i686-elf-gcc not found)*

------
https://chatgpt.com/codex/tasks/task_e_68645eeaa6c48324af634e880f308165