### PR TITLE
Add basic task and process management

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,9 @@ DISK_OBJS = ./build/disk/disk.o \
 
 KEYBOARD_OBJS = ./build/keyboard/keyboard.o \
                 ./build/keyboard/classic.o
+TASK_OBJS = ./build/task/task.o \
+            ./build/task/process.o \
+            ./build/task/task.asm.o
 
 FILES = ./build/kernel.asm.o \
         ./build/kernel.o \
@@ -17,6 +20,7 @@ FILES = ./build/kernel.asm.o \
         ./build/io.o \
         $(DISK_OBJS) \
         $(KEYBOARD_OBJS) \
+        $(TASK_OBJS) \
         ./build/memory/heap/heap.o \
         ./build/memory/heap/kheap.o \
         ./build/memory/paging/paging.o \
@@ -25,7 +29,7 @@ FILES = ./build/kernel.asm.o \
         ./build/fs/pparser.o \
         ./build/fs/fat/fat16.o
 INCLUDES = -I./src -I./src/gdt -I./src/task -I./src/idt -I./src/fs -I./src/fs/fat
-BUILD_DIRS = ./bin ./build/memory/heap ./build/memory/paging ./build/keyboard ./build/disk ./build/fs ./build/fs/fat
+BUILD_DIRS = ./bin ./build/memory/heap ./build/memory/paging ./build/keyboard ./build/disk ./build/fs ./build/fs/fat ./build/task
 FLAGS = -g -ffreestanding -falign-jumps -falign-functions -falign-labels -falign-loops -fstrength-reduce -fomit-frame-pointer -finline-functions -Wno-unused-function -fno-builtin -Werror -Wno-unused-label -Wno-cpp -Wno-unused-parameter -nostdlib -nostartfiles -nodefaultlibs -Wall -O0 -Iinc -fno-pie -no-pie
 
 dirs:
@@ -64,6 +68,15 @@ all: dirs ./bin/boot.bin ./bin/kernel.bin
 
 ./build/idt.asm.o: ./src/idt/idt.asm
 	nasm -f elf -g ./src/idt/idt.asm -o ./build/idt.asm.o
+
+./build/task/task.o: ./src/task/task.c
+	i686-elf-gcc $(INCLUDES) $(FLAGS) -std=gnu99 -c ./src/task/task.c -o ./build/task/task.o
+
+./build/task/process.o: ./src/task/process.c
+	i686-elf-gcc $(INCLUDES) $(FLAGS) -std=gnu99 -c ./src/task/process.c -o ./build/task/process.o
+
+./build/task/task.asm.o: ./src/task/task.asm
+	nasm -f elf -g ./src/task/task.asm -o ./build/task/task.asm.o
 
 ./build/memory.o: ./src/memory/memory.c
 	i686-elf-gcc $(INCLUDES) $(FLAGS) -std=gnu99 -c ./src/memory/memory.c -o ./build/memory.o

--- a/src/task/process.c
+++ b/src/task/process.c
@@ -1,0 +1,570 @@
+#include "process.h"
+#include "config.h"
+#include "status.h"
+#include "task/task.h"
+#include "memory/memory.h"
+#include "string/string.h"
+#include "fs/file.h"
+#include "memory/heap/kheap.h"
+#include "memory/paging/paging.h"
+#include "loader/formats/elfloader.h"
+#include "kernel.h"
+
+// The current process that is running
+struct process* current_process = 0;
+
+static struct process* processes[VANA_MAX_PROCESSES] = {};
+
+int process_free_process(struct process* process);
+
+
+static void process_init(struct process* process)
+{
+    memset(process, 0, sizeof(struct process));
+}
+
+struct process* process_current()
+{
+    return current_process;
+}
+
+struct process* process_get(int process_id)
+{
+    if (process_id < 0 || process_id >= VANA_MAX_PROCESSES)
+    {
+        return NULL;
+    }
+
+    return processes[process_id];
+}
+
+int process_switch(struct process* process)
+{
+    current_process = process;
+    return 0;
+}
+
+static int process_find_free_allocation_index(struct process* process)
+{
+    int res = -ENOMEM;
+    for (int i = 0; i < VANA_MAX_PROGRAM_ALLOCATIONS; i++)
+    {
+        if (process->allocations[i].ptr == 0)
+        {
+            res = i;
+            break;
+        }
+    }
+
+    return res;
+}
+
+void* process_malloc(struct process* process, size_t size)
+{
+    void* ptr = kzalloc(size);
+    if (!ptr)
+    {
+        goto out_err;
+    }
+
+    int index = process_find_free_allocation_index(process);
+    if (index < 0)
+    {
+        goto out_err;
+    }
+
+    int res = paging_map_to(process->task->page_directory, ptr, ptr, paging_align_address(ptr+size), PAGING_IS_WRITEABLE | PAGING_IS_PRESENT | PAGING_ACCESS_FROM_ALL);
+    if (res < 0)
+    {
+        goto out_err;
+    }
+
+    process->allocations[index].ptr = ptr;
+    process->allocations[index].size = size;
+    return ptr;
+
+out_err:
+    if(ptr)
+    {
+        kfree(ptr);
+    }
+    return 0;
+}
+
+static bool process_is_process_pointer(struct process* process, void* ptr)
+{
+    for (int i = 0; i < VANA_MAX_PROGRAM_ALLOCATIONS; i++)
+    {
+        if (process->allocations[i].ptr == ptr)
+            return true;
+    }
+
+    return false;
+}
+
+static void process_allocation_unjoin(struct process* process, void* ptr)
+{
+    for (int i = 0; i < VANA_MAX_PROGRAM_ALLOCATIONS; i++)
+    {
+        if (process->allocations[i].ptr == ptr)
+        {
+            process->allocations[i].ptr = 0x00;
+            process->allocations[i].size = 0;
+        }
+    }
+}
+
+static struct process_allocation* process_get_allocation_by_addr(struct process* process, void* addr)
+{
+    for (int i = 0; i < VANA_MAX_PROGRAM_ALLOCATIONS; i++)
+    {
+        if (process->allocations[i].ptr == addr)
+            return &process->allocations[i];
+    }
+
+    return 0;
+}
+
+
+int process_terminate_allocations(struct process* process)
+{
+    for (int i = 0; i < VANA_MAX_PROGRAM_ALLOCATIONS; i++)
+    {
+        if (process->allocations[i].ptr)
+        {
+            process_free(process, process->allocations[i].ptr);
+        }
+    }
+
+    return 0;
+}
+
+int process_free_binary_data(struct process* process)
+{
+    if (process->ptr)
+    {
+        kfree(process->ptr);
+    }
+    return 0;
+}
+
+int process_free_elf_data(struct process* process)
+{
+    if (process->elf_file)
+    {
+        elf_close(process->elf_file);
+    }
+
+    return 0;
+}
+int process_free_program_data(struct process* process)
+{
+    int res = 0;
+    switch(process->filetype)
+    {
+        case PROCESS_FILETYPE_BINARY:
+            res = process_free_binary_data(process);
+        break;
+
+        case PROCESS_FILETYPE_ELF:
+            res = process_free_elf_data(process);
+        break;
+
+        default:
+            res = -EINVARG;
+    }
+    return res;
+}
+
+void process_switch_to_any()
+{
+    for (int i = 0; i < VANA_MAX_PROCESSES; i++)
+    {
+        if (processes[i])
+        {
+            process_switch(processes[i]);
+            return;
+        }
+    }
+
+
+    panic("No processes to switch too\n");
+}
+
+static void process_unlink(struct process* process)
+{
+    processes[process->id] = 0x00;
+
+    if (current_process == process)
+    {
+        process_switch_to_any();
+    }
+}
+
+int process_free_process(struct process* process)
+{
+    int res = 0;
+    process_terminate_allocations(process);
+    process_free_program_data(process);
+
+    // Free the process stack memory.
+    if (process->stack)
+    {    
+        kfree(process->stack);
+        process->stack = NULL;
+    }
+    // Free the task
+    if (process->task)
+    {
+        task_free(process->task);
+        process->task = NULL;
+    }
+
+    kfree(process);
+
+out:
+    return res;
+}
+
+int process_terminate(struct process* process)
+{
+    // Unlink the process from the process array.
+    process_unlink(process);
+
+    int res = process_free_process(process);
+    if (res < 0)
+    {
+        goto out;
+    }
+
+
+out:
+    return res;
+}
+
+void process_get_arguments(struct process* process, int* argc, char*** argv)
+{
+    *argc = process->arguments.argc;
+    *argv = process->arguments.argv;
+}
+
+int process_count_command_arguments(struct command_argument* root_argument)
+{
+    struct command_argument* current = root_argument;
+    int i = 0;
+    while(current)
+    {
+        i++;
+        current = current->next;
+    }
+
+    return i;
+}
+
+
+int process_inject_arguments(struct process* process, struct command_argument* root_argument)
+{
+    int res = 0;
+    struct command_argument* current = root_argument;
+    int i = 0;
+    int argc = process_count_command_arguments(root_argument);
+    if (argc == 0)
+    {
+        res = -EIO;
+        goto out;
+    }
+
+    char **argv = process_malloc(process, sizeof(const char*) * argc);
+    if (!argv)
+    {
+        res = -ENOMEM;
+        goto out;
+    }
+
+
+    while(current)
+    {
+        char* argument_str = process_malloc(process, sizeof(current->argument));
+        if (!argument_str)
+        {
+            res = -ENOMEM;
+            goto out;
+        }
+
+        strncpy(argument_str, current->argument, sizeof(current->argument));
+        argv[i] = argument_str;
+        current = current->next;
+        i++;
+    }
+
+    process->arguments.argc = argc;
+    process->arguments.argv = argv;
+out:
+    return res;
+}
+void process_free(struct process* process, void* ptr)
+{
+    // Unlink the pages from the process for the given address
+    struct process_allocation* allocation = process_get_allocation_by_addr(process, ptr);
+    if (!allocation)
+    {
+        // Oops its not our pointer.
+        return;
+    }
+
+    int res = paging_map_to(process->task->page_directory, allocation->ptr, allocation->ptr, paging_align_address(allocation->ptr+allocation->size), 0x00);
+    if (res < 0)
+    {
+        return;
+    }
+
+    // Unjoin the allocation
+    process_allocation_unjoin(process, ptr);
+
+    // We can now free the memory.
+    kfree(ptr);
+}
+
+static int process_load_binary(const char* filename, struct process* process)
+{
+    void* program_data_ptr = 0x00;
+    int res = 0;
+    int fd = fopen(filename, "r");
+    if (!fd)
+    {
+        res = -EIO;
+        goto out;
+    }
+
+    struct file_stat stat;
+    res = fstat(fd, &stat);
+    if (res != VANA_ALL_OK)
+    {
+        goto out;
+    }
+
+    program_data_ptr = kzalloc(stat.filesize);
+    if (!program_data_ptr)
+    {
+        res = -ENOMEM;
+        goto out;
+    }
+
+    if (fread(program_data_ptr, stat.filesize, 1, fd) != 1)
+    {
+        res = -EIO;
+        goto out;
+    }
+
+    process->filetype = PROCESS_FILETYPE_BINARY;
+    process->ptr = program_data_ptr;
+    process->size = stat.filesize;
+
+out:
+    if (res < 0)
+    {
+        if (program_data_ptr)
+        {
+            kfree(program_data_ptr);
+        }
+    }
+    fclose(fd);
+    return res;
+}
+
+static int process_load_elf(const char* filename, struct process* process)
+{
+    int res = 0;
+    struct elf_file* elf_file = 0;
+    res = elf_load(filename, &elf_file);
+    if (ISERR(res))
+    {
+        goto out;
+    }
+
+    process->filetype = PROCESS_FILETYPE_ELF;
+    process->elf_file = elf_file;
+out:
+    return res;
+}
+static int process_load_data(const char* filename, struct process* process)
+{
+    int res = 0;
+    res = process_load_elf(filename, process);
+    if (res == -EINFORMAT)
+    {
+        res = process_load_binary(filename, process);
+    }
+
+    return res;
+}
+
+int process_map_binary(struct process* process)
+{
+    int res = 0;
+    paging_map_to(process->task->page_directory, (void*) VANA_PROGRAM_VIRTUAL_ADDRESS, process->ptr, paging_align_address(process->ptr + process->size), PAGING_IS_PRESENT | PAGING_ACCESS_FROM_ALL | PAGING_IS_WRITEABLE);
+    return res;
+}
+
+static int process_map_elf(struct process* process)
+{
+    int res = 0;
+
+    struct elf_file* elf_file = process->elf_file;
+    struct elf_header* header = elf_header(elf_file);
+    struct elf32_phdr* phdrs = elf_pheader(header);
+    for (int i = 0; i < header->e_phnum; i++)
+    {
+        struct elf32_phdr* phdr = &phdrs[i];
+        void* phdr_phys_address = elf_phdr_phys_address(elf_file, phdr);
+        int flags = PAGING_IS_PRESENT | PAGING_ACCESS_FROM_ALL;
+        if (phdr->p_flags & PF_W)
+        {
+            flags |= PAGING_IS_WRITEABLE;
+        }
+        res = paging_map_to(process->task->page_directory, paging_align_to_lower_page((void*)phdr->p_vaddr), paging_align_to_lower_page(phdr_phys_address), paging_align_address(phdr_phys_address+phdr->p_memsz), flags);
+        if (ISERR(res))
+        {
+            break;
+        }
+    }
+    return res;
+}
+int process_map_memory(struct process* process)
+{
+    int res = 0;
+
+    switch(process->filetype)
+    {
+        case PROCESS_FILETYPE_ELF:
+            res = process_map_elf(process);
+        break;
+
+        case PROCESS_FILETYPE_BINARY:
+            res = process_map_binary(process);
+        break;
+
+        default:
+            panic("process_map_memory: Invalid filetype\n");
+    }
+
+    if (res < 0)
+    {
+        goto out;
+    }
+
+    // Finally map the stack
+    paging_map_to(process->task->page_directory, (void*)VANA_PROGRAM_VIRTUAL_STACK_ADDRESS_END, process->stack, paging_align_address(process->stack+VANA_USER_PROGRAM_STACK_SIZE), PAGING_IS_PRESENT | PAGING_ACCESS_FROM_ALL | PAGING_IS_WRITEABLE);
+out:
+    return res;
+}
+
+int process_get_free_slot()
+{
+    for (int i = 0; i < VANA_MAX_PROCESSES; i++)
+    {
+        if (processes[i] == 0)
+            return i;
+    }
+
+    return -EISTKN;
+}
+
+int process_load(const char* filename, struct process** process)
+{
+    int res = 0;
+    int process_slot = process_get_free_slot();
+    if (process_slot < 0)
+    {
+        res = -EISTKN;
+        goto out;
+    }
+
+    res = process_load_for_slot(filename, process, process_slot);
+out:
+    return res;
+}
+
+int process_load_switch(const char* filename, struct process** process)
+{
+    int res = process_load(filename, process);
+    if (res == 0)
+    {
+        process_switch(*process);
+    }
+
+    return res;
+}
+
+int process_load_for_slot(const char* filename, struct process** process, int process_slot)
+{
+    int res = 0;
+    struct process* _process;
+
+    if (process_get(process_slot) != 0)
+    {
+        res = -EISTKN;
+        goto out;
+    }
+
+    _process = kzalloc(sizeof(struct process));
+    if (!_process)
+    {
+        res = -ENOMEM;
+        goto out;
+    }
+
+    process_init(_process);
+    res = process_load_data(filename, _process);
+    if (res < 0)
+    {
+        goto out;
+    }
+
+    _process->stack = kzalloc(VANA_USER_PROGRAM_STACK_SIZE);
+    if (!_process->stack)
+    {
+        res = -ENOMEM;
+        goto out;
+    }
+
+    strncpy(_process->filename, filename, sizeof(_process->filename));
+    _process->id = process_slot;
+
+    // Create a task
+    _process->task = task_new(_process);
+    if (ERROR_I(_process->task) == 0)
+    {
+        res = ERROR_I(_process->task);
+
+        // Task is NULL due to error code being returned in task_new.
+        _process->task = NULL;
+        goto out;
+    }
+
+
+    res = process_map_memory(_process);
+    if (res < 0)
+    {
+        goto out;
+    }
+
+    *process = _process;
+
+    // Add the process to the array
+    processes[process_slot] = _process;
+
+out:
+    if (ISERR(res))
+    {
+        if (_process)
+        {
+            process_free_process(_process);
+            _process = NULL;
+            *process = NULL;
+        }
+
+       // Free the process data
+    }
+    return res;
+}

--- a/src/task/process.h
+++ b/src/task/process.h
@@ -1,0 +1,85 @@
+#ifndef PROCESS_H
+#define PROCESS_H
+#include <stdint.h>
+#include <stdbool.h>
+
+#include "task.h"
+#include "config.h"
+
+#define PROCESS_FILETYPE_ELF 0
+#define PROCESS_FILETYPE_BINARY 1
+
+typedef unsigned char PROCESS_FILETYPE;
+
+struct process_allocation
+{
+    void* ptr;
+    size_t size;
+};
+
+struct command_argument
+{
+    char argument[512];
+    struct command_argument* next;
+};
+
+struct process_arguments
+{
+    int argc;
+    char** argv;
+};
+
+struct process
+{
+    // The process id
+    uint16_t id;
+
+    char filename[VANA_MAX_PATH];
+
+    // The main process task
+    struct task* task;
+
+    // The memory (malloc) allocations of the process
+    struct process_allocation allocations[VANA_MAX_PROGRAM_ALLOCATIONS];
+
+    PROCESS_FILETYPE filetype;
+
+    union
+    {
+        // The physical pointer to the process memory.
+        void* ptr;
+        struct elf_file* elf_file;
+    };
+    
+
+    // The physical pointer to the stack memory
+    void* stack;
+
+    // The size of the data pointed to by "ptr"
+    uint32_t size;
+
+    struct keyboard_buffer
+    {
+        char buffer[VANA_KEYBOARD_BUFFER_SIZE];
+        int tail;
+        int head;
+    } keyboard;
+
+    // The arguments of the process.
+    struct process_arguments arguments;
+};
+
+int process_switch(struct process* process);
+int process_load_switch(const char* filename, struct process** process);
+int process_load(const char* filename, struct process** process);
+int process_load_for_slot(const char* filename, struct process** process, int process_slot);
+struct process* process_current();
+struct process* process_get(int process_id);
+void* process_malloc(struct process* process, size_t size);
+void process_free(struct process* process, void* ptr);
+
+void process_get_arguments(struct process* process, int* argc, char*** argv);
+int process_inject_arguments(struct process* process, struct command_argument* root_argument);
+int process_terminate(struct process* process);
+
+#endif

--- a/src/task/task.asm
+++ b/src/task/task.asm
@@ -1,0 +1,71 @@
+[BITS 32]
+section .asm
+
+global restore_general_purpose_registers
+global task_return
+global user_registers
+
+; void task_return(struct registers* regs);
+task_return:
+    mov ebp, esp
+    ; PUSH THE DATA SEGMENT (SS WILL BE FINE)
+    ; PUSH THE STACK ADDRESS
+    ; PUSH THE FLAGS
+    ; PUSH THE CODE SEGMENT
+    ; PUSH IP
+
+    ; Let's access the structure passed to us
+    mov ebx, [ebp+4]
+    ; push the data/stack selector
+    push dword [ebx+44]
+    ; Push the stack pointer
+    push dword [ebx+40]
+
+    ; Push the flags
+    mov eax, [ebx+36]
+    or eax, 0x200 ; interrupt enable flag set
+    push eax
+
+    ; Push the code segment
+    push dword [ebx+32]
+
+    ; Push the IP to execute
+    push dword [ebx+28]
+
+    ; Setup some segment registers
+    mov ax, [ebx+44]
+    mov ds, ax
+    mov es, ax
+    mov fs, ax
+    mov gs, ax
+
+    push dword [ebp+4]
+    call restore_general_purpose_registers
+    add esp, 4
+
+    ; Let's leave kernel land and execute in user land!
+    iretd
+    
+; void restore_general_purpose_registers(struct registers* regs);
+restore_general_purpose_registers:
+    push ebp
+    mov ebp, esp
+    mov ebx, [ebp+8]
+    mov edi, [ebx]
+    mov esi, [ebx+4]
+    mov ebp, [ebx+8]
+    mov edx, [ebx+16]
+    mov ecx, [ebx+20]
+    mov eax, [ebx+24]
+    mov ebx, [ebx+12]
+    add esp, 4
+    ret
+
+; void user_registers()
+user_registers:
+    mov ax, 0x23
+    mov ds, ax
+    mov es, ax
+    mov fs, ax
+    mov gs, ax
+    ret

--- a/src/task/task.c
+++ b/src/task/task.c
@@ -1,0 +1,258 @@
+#include "task.h"
+#include "kernel.h"
+#include "status.h"
+#include "process.h"
+#include "memory/heap/kheap.h"
+#include "memory/memory.h"
+#include "string/string.h"
+#include "memory/paging/paging.h"
+#include "loader/formats/elfloader.h"
+#include "idt/idt.h"
+
+// The current task that is running
+struct task *current_task = 0;
+
+// Task linked list
+struct task *task_tail = 0;
+struct task *task_head = 0;
+
+int task_init(struct task *task, struct process *process);
+
+struct task *task_current()
+{
+    return current_task;
+}
+
+struct task *task_new(struct process *process)
+{
+    int res = 0;
+    struct task *task = kzalloc(sizeof(struct task));
+    if (!task)
+    {
+        res = -ENOMEM;
+        goto out;
+    }
+
+    res = task_init(task, process);
+    if (res != VANA_ALL_OK)
+    {
+        goto out;
+    }
+
+    if (task_head == 0)
+    {
+        task_head = task;
+        task_tail = task;
+        current_task = task;
+        goto out;
+    }
+
+    task_tail->next = task;
+    task->prev = task_tail;
+    task_tail = task;
+
+out:
+    if (ISERR(res))
+    {
+        task_free(task);
+        return ERROR(res);
+    }
+
+    return task;
+}
+
+struct task *task_get_next()
+{
+    if (!current_task->next)
+    {
+        return task_head;
+    }
+
+    return current_task->next;
+}
+
+static void task_list_remove(struct task *task)
+{
+    if (task->prev)
+    {
+        task->prev->next = task->next;
+    }
+
+    if (task == task_head)
+    {
+        task_head = task->next;
+    }
+
+    if (task == task_tail)
+    {
+        task_tail = task->prev;
+    }
+
+    if (task == current_task)
+    {
+        current_task = task_get_next();
+    }
+}
+
+int task_free(struct task *task)
+{
+    paging_free_4gb(task->page_directory);
+    task_list_remove(task);
+
+    // Finally free the task data
+    kfree(task);
+    return 0;
+}
+
+void task_next()
+{
+    struct task* next_task = task_get_next();
+    if (!next_task)
+    {
+        panic("No more tasks!\n");
+    }
+
+    task_switch(next_task);
+    task_return(&next_task->registers);
+}
+
+int task_switch(struct task *task)
+{
+    current_task = task;
+    paging_switch(task->page_directory);
+    return 0;
+}
+
+void task_save_state(struct task *task, struct interrupt_frame *frame)
+{
+    task->registers.ip = frame->ip;
+    task->registers.cs = frame->cs;
+    task->registers.flags = frame->flags;
+    task->registers.esp = frame->esp;
+    task->registers.ss = frame->ss;
+    task->registers.eax = frame->eax;
+    task->registers.ebp = frame->ebp;
+    task->registers.ebx = frame->ebx;
+    task->registers.ecx = frame->ecx;
+    task->registers.edi = frame->edi;
+    task->registers.edx = frame->edx;
+    task->registers.esi = frame->esi;
+}
+int copy_string_from_task(struct task* task, void* virtual, void* phys, int max)
+{
+    if (max >= PAGING_PAGE_SIZE)
+    {
+        return -EINVARG;
+    }
+
+    int res = 0;
+    char* tmp = kzalloc(max);
+    if (!tmp)
+    {
+        res = -ENOMEM;
+        goto out;
+    }
+
+    uint32_t* task_directory = task->page_directory->directory_entry;
+    uint32_t old_entry = paging_get(task_directory, tmp);
+    paging_map(task->page_directory, tmp, tmp, PAGING_IS_WRITEABLE | PAGING_IS_PRESENT | PAGING_ACCESS_FROM_ALL);
+    paging_switch(task->page_directory);
+    strncpy(tmp, virtual, max);
+    kernel_page();
+
+    res = paging_set(task_directory, tmp, old_entry);
+    if (res < 0)
+    {
+        res = -EIO;
+        goto out_free;
+    }
+
+    strncpy(phys, tmp, max);
+
+out_free:
+    kfree(tmp);
+out:
+    return res;
+}
+void task_current_save_state(struct interrupt_frame *frame)
+{
+    if (!task_current())
+    {
+        panic("No current task to save\n");
+    }
+
+    struct task *task = task_current();
+    task_save_state(task, frame);
+}
+
+int task_page()
+{
+    user_registers();
+    task_switch(current_task);
+    return 0;
+}
+
+int task_page_task(struct task* task)
+{
+    user_registers();
+    paging_switch(task->page_directory);
+    return 0;
+}
+
+void task_run_first_ever_task()
+{
+    if (!current_task)
+    {
+        panic("task_run_first_ever_task(): No current task exists!\n");
+    }
+
+    task_switch(task_head);
+    task_return(&task_head->registers);
+}
+
+int task_init(struct task *task, struct process *process)
+{
+    memset(task, 0, sizeof(struct task));
+    // Map the entire 4GB address space to its self
+    task->page_directory = paging_new_4gb(PAGING_IS_PRESENT | PAGING_ACCESS_FROM_ALL);
+    if (!task->page_directory)
+    {
+        return -EIO;
+    }
+
+    task->registers.ip = VANA_PROGRAM_VIRTUAL_ADDRESS;
+    if (process->filetype == PROCESS_FILETYPE_ELF)
+    {
+        task->registers.ip = elf_header(process->elf_file)->e_entry;
+    }
+
+    task->registers.ss = USER_DATA_SEGMENT;
+    task->registers.cs = USER_CODE_SEGMENT;
+    task->registers.esp = VANA_PROGRAM_VIRTUAL_STACK_ADDRESS_START;
+
+    task->process = process;
+
+    return 0;
+}
+
+void* task_get_stack_item(struct task* task, int index)
+{
+    void* result = 0;
+
+    uint32_t* sp_ptr = (uint32_t*) task->registers.esp;
+
+    // Switch to the given tasks page
+    task_page_task(task);
+
+    result = (void*) sp_ptr[index];
+
+    // Switch back to the kernel page
+    kernel_page();
+
+    return result;
+}
+
+void* task_virtual_address_to_physical(struct task* task, void* virtual_address)
+{
+    return paging_get_physical_address(task->page_directory->directory_entry, virtual_address);
+}

--- a/src/task/task.h
+++ b/src/task/task.h
@@ -1,0 +1,68 @@
+#ifndef TASK_H
+#define TASK_H
+
+#include "config.h"
+#include "memory/paging/paging.h"
+
+struct interrupt_frame;
+struct registers
+{
+    uint32_t edi;
+    uint32_t esi;
+    uint32_t ebp;
+    uint32_t ebx;
+    uint32_t edx;
+    uint32_t ecx;
+    uint32_t eax;
+
+    uint32_t ip;
+    uint32_t cs;
+    uint32_t flags;
+    uint32_t esp;
+    uint32_t ss;
+};
+
+
+struct process;
+struct task
+{
+    /**
+     * The page directory of the task
+     */
+    struct paging_4gb_chunk* page_directory;
+
+    // The registers of the task when the task is not running
+    struct registers registers;
+
+    // The process of the task
+    struct process* process;
+
+    // The next task in the linked list
+    struct task* next;
+
+    // Previous task in the linked list
+    struct task* prev;
+};
+
+struct task* task_new(struct process* process);
+struct task* task_current();
+struct task* task_get_next();
+int task_free(struct task* task);
+
+int task_switch(struct task* task);
+int task_page();
+int task_page_task(struct task* task);
+
+void task_run_first_ever_task();
+
+void task_return(struct registers* regs);
+void restore_general_purpose_registers(struct registers* regs);
+void user_registers();
+
+void task_current_save_state(struct interrupt_frame *frame);
+int copy_string_from_task(struct task* task, void* virtual, void* phys, int max);
+void* task_get_stack_item(struct task* task, int index);
+void* task_virtual_address_to_physical(struct task* task, void* virtual_address);
+void task_next();
+
+#endif


### PR DESCRIPTION
## Summary
- port task handling files from reference kernel
- port process manager using VANA_* constants
- provide assembly helpers for task switching
- update Makefile build rules for new task sources

## Testing
- `make all` *(fails: `i686-elf-gcc: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_68649a23297883249cec408714c7bd3f