### PR TITLE
Add kernel_registers label for scheduler

### DIFF
--- a/src/kernel.asm
+++ b/src/kernel.asm
@@ -1,6 +1,7 @@
 [BITS 32]
 
 global _start
+global kernel_registers
 extern kernel_main
 
 CODE_SEG equ 0x08
@@ -43,5 +44,13 @@ _start:
     call kernel_main
 
     jmp $
+
+kernel_registers:
+    mov ax, DATA_SEG
+    mov ds, ax
+    mov es, ax
+    mov gs, ax
+    mov fs, ax
+    ret
 
 times 512-($ - $$) db 0

--- a/src/kernel.h
+++ b/src/kernel.h
@@ -8,6 +8,7 @@
 void kernel_main();
 void print(const char* str);
 void panic(const char* msg);
+void kernel_registers();
 
 #define ERROR(value)  ((void*)(value))
 #define ERROR_I(value) ((int)(value))


### PR DESCRIPTION
## Summary
- export a new `kernel_registers` symbol in `kernel.asm`
- declare the function in `kernel.h`

## Testing
- `./build-toolchain.sh` *(fails: 503 Service Unavailable)*
- `make ./bin/kernel.bin` *(fails: `i686-elf-gcc` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68649dc4b2f88324b09ed7f518523dcf