### PR TITLE
Implement syscall handler framework

### DIFF
--- a/src/idt/idt.asm
+++ b/src/idt/idt.asm
@@ -3,11 +3,13 @@ section .asm
 
 extern interrupt_handler
 extern no_interrupt_handler
+extern isr80h_handler
 
 global idt_load
 global no_interrupt
 global enable_interrupts
 global disable_interrupts
+global isr80h_wrapper
 global interrupt_pointer_table
 
 enable_interrupts:
@@ -49,6 +51,22 @@ no_interrupt:
     interrupt i
 %assign i i+1
 %endrep
+
+isr80h_wrapper:
+    ; INTERRUPT FRAME START
+    pushad
+    ; INTERRUPT FRAME END
+    push esp
+    push eax
+    call isr80h_handler
+    mov [tmp_res], eax
+    add esp, 8
+    popad
+    mov eax, [tmp_res]
+    iretd
+
+section .data
+tmp_res: dd 0
 
 %macro interrupt_array_entry 1
     dd int%1

--- a/src/idt/idt.h
+++ b/src/idt/idt.h
@@ -4,6 +4,7 @@
 #include <stdint.h>
 
 struct interrupt_frame;
+typedef void*(*ISR80H_COMMAND)(struct interrupt_frame* frame);
 
 typedef void(*INTERRUPT_CALLBACK_FUNCTION)(struct interrupt_frame* frame);
 
@@ -42,6 +43,9 @@ struct interrupt_frame
 void idt_init();
 void enable_interrupts();
 void disable_interrupts();
+void isr80h_register_command(int command_id, ISR80H_COMMAND command);
+void* isr80h_handle_command(int command, struct interrupt_frame* frame);
+void* isr80h_handler(int command, struct interrupt_frame* frame);
 int idt_register_interrupt_callback(int interrupt, INTERRUPT_CALLBACK_FUNCTION interrupt_callback);
 void interrupt_ignore(struct interrupt_frame* frame);
 


### PR DESCRIPTION
## Summary
- add ISR80H command definitions
- keep a syscall command table and dispatch
- add assembly wrapper for isr80h
- hook isr80h in idt initialization

## Testing
- `bash build-toolchain.sh` *(fails: 503 Service Unavailable)*
- `bash build.sh` *(fails: i686-elf-gcc: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6864a3d1004c8324a601d7fce251460a