### PR TITLE
Register ISR80H commands earlier

### DIFF
--- a/src/kernel.c
+++ b/src/kernel.c
@@ -9,6 +9,7 @@
 #include "memory/paging/paging.h"
 #include "task/process.h"
 #include "task/task.h"
+#include "isr80h/isr80h.h"
 #include "disk/disk.h"
 #include "disk/streamer.h"
 #include "fs/file.h"
@@ -124,6 +125,7 @@ void kernel_main()
 
     // With the GDT and TSS active we can setup the IDT
     idt_init();
+    isr80h_register_commands();
     print("IDT initialized.\n");
 
     // Ignore spurious timer interrupts until proper handlers exist


### PR DESCRIPTION
## Summary
- include ISR80H header in the kernel
- register syscall commands directly after IDT initialization

## Testing
- `./build-toolchain.sh` *(fails: 503 Service Unavailable)*
- `./build.sh` *(fails: i686-elf-gcc: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6864a82c5ba08324965391cae0b6afa8