### PR TITLE
Fix linkage for isr80h_handle_command

### DIFF
--- a/src/idt/idt.c
+++ b/src/idt/idt.c
@@ -126,7 +126,7 @@ void isr80h_register_command(int command_id, ISR80H_COMMAND command)
     isr80h_commands[command_id] = command;
 }
 
-static void* isr80h_handle_command(int command, struct interrupt_frame* frame)
+void* isr80h_handle_command(int command, struct interrupt_frame* frame)
 {
     void* result = 0;
 


### PR DESCRIPTION
## Summary
- expose `isr80h_handle_command` by removing `static`

## Testing
- `bash ./build-toolchain.sh` *(fails: 503 Service Unavailable)*
- `make all` *(fails: i686-elf-gcc not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864b51a81e883249e80240bd40c47e9