### PR TITLE
Launch shell program by default

### DIFF
--- a/src/kernel.c
+++ b/src/kernel.c
@@ -148,10 +148,10 @@ void kernel_main()
     print("Paging enabled.\n");
 
     struct process* process = NULL;
-    int res = process_load_switch("0:/blank.elf", &process);
+    int res = process_load_switch("0:/shell.elf", &process);
     if (res != VANA_ALL_OK)
     {
-        panic("Failed to load blank.elf\n");
+        panic("Failed to load shell.elf\n");
     }
 
     // Unmask timer (IRQ0) and keyboard (IRQ1) lines now that handlers exist


### PR DESCRIPTION
## Summary
- load `shell.elf` instead of the old blank program

## Testing
- `make all` *(fails: `i686-elf-gcc` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68654eaf9ee883249492855bebbf7693