### PR TITLE
Fix build dir creation for program Makefiles

### DIFF
--- a/programs/blank/Makefile
+++ b/programs/blank/Makefile
@@ -1,11 +1,15 @@
-FILES=./build/blank.o
+BUILD_DIR=./build
+FILES=$(BUILD_DIR)/blank.o
 INCLUDES= -I../stdlib/src
 FLAGS= -g -ffreestanding -falign-jumps -falign-functions -falign-labels -falign-loops -fstrength-reduce -fomit-frame-pointer -finline-functions -Wno-unused-function -fno-builtin -Werror -Wno-unused-label -Wno-cpp -Wno-unused-parameter -nostdlib -nostartfiles -nodefaultlibs -Wall -O0 -Iinc
-all: ${FILES}
+all: $(BUILD_DIR) ${FILES}
 	i686-elf-gcc -g -T ./linker.ld -o ./blank.elf -ffreestanding -O0 -nostdlib -fpic -g ${FILES} ../stdlib/build/libvana.o
 
-./build/blank.o: ./blank.c
-	i686-elf-gcc ${INCLUDES} -I./ $(FLAGS) -std=gnu99 -c ./blank.c -o ./build/blank.o
+$(BUILD_DIR):
+	mkdir -p $(BUILD_DIR)
+
+$(BUILD_DIR)/blank.o: ./blank.c
+	i686-elf-gcc ${INCLUDES} -I./ $(FLAGS) -std=gnu99 -c ./blank.c -o $(BUILD_DIR)/blank.o
 
 clean:
 	rm -rf ${FILES}

--- a/programs/shell/Makefile
+++ b/programs/shell/Makefile
@@ -1,11 +1,15 @@
-FILES=./build/shell.o
+BUILD_DIR=./build
+FILES=$(BUILD_DIR)/shell.o
 INCLUDES= -I../stdlib/src
 FLAGS= -g -ffreestanding -falign-jumps -falign-functions -falign-labels -falign-loops -fstrength-reduce -fomit-frame-pointer -finline-functions -Wno-unused-function -fno-builtin -Werror -Wno-unused-label -Wno-cpp -Wno-unused-parameter -nostdlib -nostartfiles -nodefaultlibs -Wall -O0 -Iinc
-all: ${FILES}
+all: $(BUILD_DIR) ${FILES}
 	i686-elf-gcc -g -T ./linker.ld -o ./shell.elf -ffreestanding -O0 -nostdlib -fpic -g ${FILES} ../stdlib/build/libvana.o
 
-./build/shell.o: ./src/shell.c
-	i686-elf-gcc ${INCLUDES} -I./ $(FLAGS) -std=gnu99 -c ./src/shell.c -o ./build/shell.o
+$(BUILD_DIR):
+	mkdir -p $(BUILD_DIR)
+
+$(BUILD_DIR)/shell.o: ./src/shell.c
+	i686-elf-gcc ${INCLUDES} -I./ $(FLAGS) -std=gnu99 -c ./src/shell.c -o $(BUILD_DIR)/shell.o
 
 clean:
 	rm -rf ${FILES}

--- a/programs/stdlib/Makefile
+++ b/programs/stdlib/Makefile
@@ -13,8 +13,11 @@ FILES=$(BUILD_DIR)/start.asm.o \
 INCLUDES=-I$(SRC_DIR)
 FLAGS=-g -ffreestanding -fno-builtin -Wall -O0 -nostdlib -nostartfiles -nodefaultlibs
 
-all: $(FILES)
+all: $(BUILD_DIR) $(FILES)
 	i686-elf-ld -m elf_i386 -relocatable $(FILES) -o $(BUILD_DIR)/libvana.o
+
+$(BUILD_DIR):
+	mkdir -p $(BUILD_DIR)
 
 $(BUILD_DIR)/%.asm.o: $(SRC_DIR)/%.asm
 	nasm -f elf $< -o $@


### PR DESCRIPTION
## Summary
- update `programs/blank`, `programs/shell` and `programs/stdlib` Makefiles to always create their `build` directories

## Testing
- `bash build-toolchain.sh` *(fails: proxy blocked while downloading)*
- `make -C programs/stdlib all` *(fails: `i686-elf-gcc` missing)*
- `make -C programs/blank all` *(fails: `i686-elf-gcc` missing)*
- `make -C programs/shell all` *(fails: `i686-elf-gcc` missing)*

------
https://chatgpt.com/codex/tasks/task_e_68655490d3248324990f1fcbaa06e6e3