### PR TITLE
Update shell to use vana system calls

### DIFF
--- a/programs/shell/src/shell.c
+++ b/programs/shell/src/shell.c
@@ -9,9 +9,9 @@ int main(int argc, char** argv)
     {
         print("> ");
         char buf[1024];
-        peachos_terminal_readline(buf, sizeof(buf), true);
+        vana_terminal_readline(buf, sizeof(buf), true);
         print("\n");
-        peachos_system_run(buf);
+        vana_system_run(buf);
         
         print("\n");
     }


### PR DESCRIPTION
## Summary
- adapt shell to use `vana_terminal_readline` and `vana_system_run`
- these updates ensure the shell relies on libvana APIs

## Testing
- `make -C programs/stdlib clean all` *(fails: `i686-elf-gcc: No such file or directory`)*
- `make -C programs/shell all` *(fails: `i686-elf-gcc: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_686562089a288324924dd8d11ffb1855