### PR TITLE
Fix boot program loading

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,12 +44,10 @@ dirs:
 
 user_programs:
 	cd ./programs/stdlib && $(MAKE) all
-	cd ./programs/blank && $(MAKE) all
 	cd ./programs/shell && $(MAKE) all
 
 user_programs_clean:
 	- cd ./programs/stdlib && $(MAKE) clean
-	- cd ./programs/blank && $(MAKE) clean
 	- cd ./programs/shell && $(MAKE) clean
 
 all: user_programs dirs ./bin/boot.bin ./bin/kernel.bin
@@ -58,7 +56,6 @@ all: user_programs dirs ./bin/boot.bin ./bin/kernel.bin
 	dd if=./bin/kernel.bin >> ./bin/os.bin
 	dd if=/dev/zero bs=1048576 count=16 >> ./bin/os.bin
 	sudo mount -t vfat ./bin/os.bin /mnt/d
-	sudo cp ./programs/blank/blank.elf /mnt/d
 	sudo cp ./programs/shell/shell.elf /mnt/d
 	sudo umount /mnt/d
 


### PR DESCRIPTION
## Summary
- clean up Makefile to stop building and copying the blank test program
- ensure the kernel loads `shell.elf` only

## Testing
- `make -n all`

------
https://chatgpt.com/codex/tasks/task_e_686568738f948324bcbf2606aa29f64e