### PR TITLE
Add user GDT entries

### DIFF
--- a/src/kernel.c
+++ b/src/kernel.c
@@ -1,6 +1,7 @@
 #include "kernel.h"
 #include "string/string.h"
 #include "memory/memory.h"
+#include "config.h"
 #include "gdt/gdt.h"
 #include "task/tss.h"
 #include "idt/idt.h"
@@ -25,11 +26,13 @@ uint16_t terminal_row = 0;
 uint16_t terminal_col = 0;
 
 struct tss tss;
-struct gdt gdt_real[4];
-struct gdt_structured gdt_structured[4] = {
+struct gdt gdt_real[VANA_TOTAL_GDT_SEGMENTS];
+struct gdt_structured gdt_structured[VANA_TOTAL_GDT_SEGMENTS] = {
     {.base = 0x00, .limit = 0x00, .type = 0x00},                // Null segment
     {.base = 0x00, .limit = 0xffffffff, .type = 0x9a},         // Kernel code
     {.base = 0x00, .limit = 0xffffffff, .type = 0x92},         // Kernel data
+    {.base = 0x00, .limit = 0xffffffff, .type = 0xf8},         // User code
+    {.base = 0x00, .limit = 0xffffffff, .type = 0xf2},         // User data
     {.base = (uint32_t)&tss, .limit = sizeof(tss), .type = 0xE9} // TSS
 };
 
@@ -106,7 +109,7 @@ void kernel_main()
     disable_interrupts();
 
     memset(gdt_real, 0x00, sizeof(gdt_real));
-    gdt_structured_to_gdt(gdt_real, gdt_structured, 4);
+    gdt_structured_to_gdt(gdt_real, gdt_structured, VANA_TOTAL_GDT_SEGMENTS);
     struct gdt_descriptor desc;
     desc.size = sizeof(gdt_real) - 1;
     desc.address = (uint32_t)gdt_real;


### PR DESCRIPTION
## Summary
- include `config.h` in the kernel
- expand GDT tables to `VANA_TOTAL_GDT_SEGMENTS`
- add user mode code and data descriptors
- use the segment count when constructing the GDT

## Testing
- `make all` *(fails: i686-elf-gcc not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865a234b85c8324b0b7373de30bf3e0