### PR TITLE
Update GDT TSS selector

### DIFF
--- a/src/gdt/gdt.h
+++ b/src/gdt/gdt.h
@@ -5,7 +5,7 @@
 
 #define GDT_KERNEL_CODE_SELECTOR 0x08
 #define GDT_KERNEL_DATA_SELECTOR 0x10
-#define GDT_TSS_SELECTOR 0x18
+#define GDT_TSS_SELECTOR 0x28
 
 struct gdt
 {


### PR DESCRIPTION
## Summary
- update GDT_TSS_SELECTOR to 0x28
- use updated selector when loading TSS

## Testing
- `bash build.sh` *(fails: i686-elf-gcc not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865a3a7f2748324ad770c4cf6e5c319