### PR TITLE
Enable user-accessible syscall vector

### DIFF
--- a/src/idt/idt.c
+++ b/src/idt/idt.c
@@ -34,13 +34,13 @@ static void idt_handle_exception(struct interrupt_frame* frame)
     print("CPU exception\n");
 }
 
-static void idt_set(int interrupt_no, void* address)
+static void idt_set(int interrupt_no, void* address, uint8_t type_attr)
 {
     struct idt_desc* desc = &idt_descriptors[interrupt_no];
     desc->offset_1 = (uint32_t)address & 0xFFFF;
     desc->selector = GDT_KERNEL_CODE_SELECTOR;
     desc->zero = 0;
-    desc->type_attr = 0x8E;
+    desc->type_attr = type_attr;
     desc->offset_2 = (uint32_t)address >> 16;
 }
 
@@ -82,10 +82,10 @@ void idt_init()
 
     for (int i = 0; i < IDT_TOTAL_DESCRIPTORS; i++)
     {
-        idt_set(i, interrupt_pointer_table[i]);
+        idt_set(i, interrupt_pointer_table[i], IDT_DESC_KERNEL_INTERRUPT_GATE);
     }
 
-    idt_set(0x80, isr80h_wrapper);
+    idt_set(0x80, isr80h_wrapper, IDT_DESC_USER_INTERRUPT_GATE);
 
     memset(interrupt_callbacks, 0, sizeof(interrupt_callbacks));
 

--- a/src/idt/idt.h
+++ b/src/idt/idt.h
@@ -3,6 +3,16 @@
 
 #include <stdint.h>
 
+/* IDT gate type and attribute flags */
+#define IDT_DESC_PRESENT 0x80
+#define IDT_DESC_BIT32   0x08
+#define IDT_DESC_INT_GATE 0x0E
+#define IDT_DESC_RING3   0x60
+#define IDT_DESC_RING0   0x00
+
+#define IDT_DESC_KERNEL_INTERRUPT_GATE (IDT_DESC_PRESENT | IDT_DESC_RING0 | IDT_DESC_INT_GATE)
+#define IDT_DESC_USER_INTERRUPT_GATE   (IDT_DESC_PRESENT | IDT_DESC_RING3 | IDT_DESC_INT_GATE)
+
 struct interrupt_frame;
 typedef void*(*ISR80H_COMMAND)(struct interrupt_frame* frame);
 


### PR DESCRIPTION
## Summary
- allow overriding IDT descriptor attributes when initializing vectors
- add macros for descriptor flags
- configure vector `0x80` as a user level interrupt gate

## Testing
- `gcc -m32 -ffreestanding -c src/idt/idt.c -I./src -I./src/gdt -I./src/task -I./src/idt -I./src/fs -I./src/fs/fat -I./src/loader/formats -I./src/isr80h -o /tmp/idt.o`
- `make all` *(fails: `i686-elf-gcc: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_6865aa358de08324a6aabfda924cac87