### PR TITLE
Fix keyboard IRQ registration

### DIFF
--- a/src/keyboard/classic.c
+++ b/src/keyboard/classic.c
@@ -33,6 +33,7 @@ void classic_keyboard_handle_interrupt();
 
 int classic_keyboard_init()
 {
+    idt_register_interrupt_callback(ISR_KEYBOARD_INTERRUPT, classic_keyboard_handle_interrupt);
     keyboard_set_capslock(&classic_keyboard, KEYBOARD_CAPS_LOCK_OFF);
     outb(PS2_PORT, PS2_COMMAND_ENABLE_FIRST_PORT);
     return 0;


### PR DESCRIPTION
## Summary
- register the classic keyboard interrupt handler during initialization

## Testing
- `make all` *(fails: `i686-elf-gcc` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865af2b3518832495a027eaad3a39b4