### PR TITLE
Remove unused keyboard IRQ handler

### DIFF
--- a/src/keyboard/keyboard.c
+++ b/src/keyboard/keyboard.c
@@ -17,12 +17,9 @@ struct keyboard_buffer
 
 static struct keyboard_buffer kbuffer;
 
-static void keyboard_irq_handler(struct interrupt_frame* frame);
-
 void keyboard_init()
 {
     keyboard_insert(classic_init());
-    idt_register_interrupt_callback(ISR_KEYBOARD_INTERRUPT, keyboard_irq_handler);
 }
 
 int keyboard_insert(struct keyboard* keyboard)
@@ -53,13 +50,6 @@ static int keyboard_get_tail_index()
     return kbuffer.tail % VANA_KEYBOARD_BUFFER_SIZE;
 }
 
-static void keyboard_irq_handler(struct interrupt_frame* frame)
-{
-    (void)frame;
-    uint8_t scancode = insb(KEYBOARD_INPUT_PORT);
-    insb(KEYBOARD_INPUT_PORT);
-    keyboard_push((char)scancode);
-}
 
 void keyboard_backspace()
 {


### PR DESCRIPTION
## Summary
- stop registering a keyboard IRQ handler
- remove the unused handler implementation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6865b2c0a4b48324b9d25ed489e80050