### PR TITLE
Add keyboard shift state

### DIFF
--- a/src/keyboard/classic.c
+++ b/src/keyboard/classic.c
@@ -35,6 +35,7 @@ int classic_keyboard_init()
 {
     idt_register_interrupt_callback(ISR_KEYBOARD_INTERRUPT, classic_keyboard_handle_interrupt);
     keyboard_set_capslock(&classic_keyboard, KEYBOARD_CAPS_LOCK_OFF);
+    keyboard_set_shift(&classic_keyboard, KEYBOARD_SHIFT_OFF);
     outb(PS2_PORT, PS2_COMMAND_ENABLE_FIRST_PORT);
     return 0;
 }

--- a/src/keyboard/keyboard.c
+++ b/src/keyboard/keyboard.c
@@ -70,6 +70,16 @@ KEYBOARD_CAPS_LOCK_STATE keyboard_get_capslock(struct keyboard* keyboard)
     return keyboard->capslock_state;
 }
 
+void keyboard_set_shift(struct keyboard* keyboard, int state)
+{
+    keyboard->shift_state = state;
+}
+
+int keyboard_get_shift(const struct keyboard* keyboard)
+{
+    return keyboard->shift_state;
+}
+
 void keyboard_push(char c)
 {
     if (c == 0)

--- a/src/keyboard/keyboard.h
+++ b/src/keyboard/keyboard.h
@@ -7,6 +7,9 @@
 #define KEYBOARD_CAPS_LOCK_ON 1
 #define KEYBOARD_CAPS_LOCK_OFF 0
 
+#define KEYBOARD_SHIFT_ON 1
+#define KEYBOARD_SHIFT_OFF 0
+
 typedef int KEYBOARD_CAPS_LOCK_STATE;
 
 typedef int (*KEYBOARD_INIT_FUNCTION)();
@@ -16,6 +19,7 @@ struct keyboard
     KEYBOARD_INIT_FUNCTION init;
     char name[20];
     KEYBOARD_CAPS_LOCK_STATE capslock_state;
+    int shift_state;
     struct keyboard* next;
 };
 
@@ -26,5 +30,7 @@ char keyboard_pop();
 int keyboard_insert(struct keyboard* keyboard);
 void keyboard_set_capslock(struct keyboard* keyboard, KEYBOARD_CAPS_LOCK_STATE state);
 KEYBOARD_CAPS_LOCK_STATE keyboard_get_capslock(struct keyboard* keyboard);
+void keyboard_set_shift(struct keyboard* keyboard, int state);
+int keyboard_get_shift(const struct keyboard* keyboard);
 
 #endif


### PR DESCRIPTION
## Summary
- extend struct `keyboard` with a `shift_state` field
- add macros for shift on/off states
- implement getter/setter for keyboard shift state
- initialize shift state for the classic keyboard

## Testing
- `make all` *(fails: `i686-elf-gcc` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865b4ae9f50832487de9f22fe6d9c84