### PR TITLE
Update boot branding to Vana

### DIFF
--- a/programs/shell/src/shell.c
+++ b/programs/shell/src/shell.c
@@ -4,7 +4,7 @@
 #include "vana.h"
 int main(int argc, char** argv)
 {
-    print("PeachOS v1.0.0\n");
+    print("VanaOS v1.0.0\n");
     while(1) 
     {
         print("> ");

--- a/src/boot/boot.asm
+++ b/src/boot/boot.asm
@@ -9,7 +9,7 @@ _start:
     nop
 
 ; FAT16 Header
-OEMIdentifier           db 'PEACHOS '
+OEMIdentifier           db 'VANA    '
 BytesPerSector          dw 0x200
 SectorsPerCluster       db 0x80
 ReservedSectors         dw 200
@@ -27,7 +27,7 @@ DriveNumber             db 0x80
 WinNTBit                db 0x00
 Signature               db 0x29
 VolumeID                dd 0xD105
-VolumeIDString          db 'PEACHOS BOO'
+VolumeIDString          db 'VANAOS BOOT'
 SystemIDString          db 'FAT16   '
  
 start:


### PR DESCRIPTION
## Summary
- rename PeachOS boot identifiers to Vana
- adjust shell greeting

## Testing
- `make all` *(fails: `i686-elf-gcc: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_6865f99e8d3c83249f17cc45951512de