### PR TITLE
Add libc startup crt0

### DIFF
--- a/programs/libc/startup/crt0.s
+++ b/programs/libc/startup/crt0.s
@@ -1,0 +1,14 @@
+.section .text
+.globl _start
+.align 4
+
+_start:
+    pop %eax          # argc
+    mov %esp, %ebx    # argv
+    push $0           # fake return address
+    push %ebx         # argv
+    push %eax         # argc
+    call main
+    mov %eax, %ebx    # status -> ebx
+    mov $VANA_SYS_EXIT, %eax
+    int $0x80


### PR DESCRIPTION
## Summary
- add `_start` implementation for libc startup in AT&T assembly

## Testing
- `make all` *(fails: `i686-elf-gcc` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866a38cc8648324abdce2aac990316b