### PR TITLE
Normalize ISR80h handler return codes

### DIFF
--- a/src/isr80h/heap.c
+++ b/src/isr80h/heap.c
@@ -3,14 +3,15 @@
 #include "task/process.h"
 #include <stddef.h>
 
-void* isr80h_command4_malloc(struct interrupt_frame* frame)
+int isr80h_command4_malloc(struct interrupt_frame* frame)
 {
     (void)frame;
     size_t size = (int)task_get_stack_item(task_current(), 0);
-    return process_malloc(task_current()->process, size);
+    void* ptr = process_malloc(task_current()->process, size);
+    return (int)ptr;
 }
 
-void* isr80h_command5_free(struct interrupt_frame* frame)
+int isr80h_command5_free(struct interrupt_frame* frame)
 {
     (void)frame;
     void* ptr_to_free = task_get_stack_item(task_current(), 0);

--- a/src/isr80h/heap.h
+++ b/src/isr80h/heap.h
@@ -3,7 +3,7 @@
 
 struct interrupt_frame;
 
-void* isr80h_command4_malloc(struct interrupt_frame* frame);
-void* isr80h_command5_free(struct interrupt_frame* frame);
+int isr80h_command4_malloc(struct interrupt_frame* frame);
+int isr80h_command5_free(struct interrupt_frame* frame);
 
 #endif

--- a/src/isr80h/io.c
+++ b/src/isr80h/io.c
@@ -3,7 +3,7 @@
 #include "keyboard/keyboard.h"
 #include "kernel.h"
 
-void* isr80h_command1_print(struct interrupt_frame* frame)
+int isr80h_command1_print(struct interrupt_frame* frame)
 {
     (void)frame;
     void* user_space_msg_buffer = task_get_stack_item(task_current(), 0);
@@ -13,14 +13,14 @@ void* isr80h_command1_print(struct interrupt_frame* frame)
     return 0;
 }
 
-void* isr80h_command2_getkey(struct interrupt_frame* frame)
+int isr80h_command2_getkey(struct interrupt_frame* frame)
 {
     (void)frame;
     char c = keyboard_pop();
-    return (void*)((int)c);
+    return (int)c;
 }
 
-void* isr80h_command3_putchar(struct interrupt_frame* frame)
+int isr80h_command3_putchar(struct interrupt_frame* frame)
 {
     char c = (char)(int)task_get_stack_item(task_current(), 0);
     terminal_writechar(c, 15);

--- a/src/isr80h/io.h
+++ b/src/isr80h/io.h
@@ -3,8 +3,8 @@
 
 struct interrupt_frame;
 
-void* isr80h_command1_print(struct interrupt_frame* frame);
-void* isr80h_command2_getkey(struct interrupt_frame* frame);
-void* isr80h_command3_putchar(struct interrupt_frame* frame);
+int isr80h_command1_print(struct interrupt_frame* frame);
+int isr80h_command2_getkey(struct interrupt_frame* frame);
+int isr80h_command3_putchar(struct interrupt_frame* frame);
 
 #endif

--- a/src/isr80h/isr80h.c
+++ b/src/isr80h/isr80h.c
@@ -16,7 +16,7 @@ void isr80h_syscall(struct interrupt_frame* context)
     switch (context->eax)
     {
         case VANA_SYS_EXIT:
-            context->eax = (int)isr80h_command9_exit(context);
+            context->eax = isr80h_command9_exit(context);
             break;
         /* handle other VANA_SYS_* calls */
         default:

--- a/src/isr80h/misc.c
+++ b/src/isr80h/misc.c
@@ -1,11 +1,11 @@
 #include "misc.h"
 #include "task/task.h"
 
-void* isr80h_command0_sum(struct interrupt_frame* frame)
+int isr80h_command0_sum(struct interrupt_frame* frame)
 {
     (void)frame;
     int a = (int)task_get_stack_item(task_current(), 0);
     int b = (int)task_get_stack_item(task_current(), 1);
     int result = a + b;
-    return (void*) result;
+    return result;
 }

--- a/src/isr80h/misc.h
+++ b/src/isr80h/misc.h
@@ -3,6 +3,6 @@
 
 struct interrupt_frame;
 
-void* isr80h_command0_sum(struct interrupt_frame* frame);
+int isr80h_command0_sum(struct interrupt_frame* frame);
 
 #endif

--- a/src/isr80h/process.c
+++ b/src/isr80h/process.c
@@ -5,8 +5,22 @@
 #include "status.h"
 #include "config.h"
 #include "kernel.h"
+#include "vana/syscall.h"
 
-void* isr80h_command6_process_load_start(struct interrupt_frame* frame)
+static int kernel_to_vana_errno(int err)
+{
+    switch (err)
+    {
+        case -EINVARG: return VANA_EINVAL;
+        case -ENOMEM:  return VANA_ENOMEM;
+        case -EIO:     return VANA_EIO;
+        case -EBADPATH:return VANA_ENOENT;
+        case -EUNIMP:  return VANA_ENOSYS;
+        default:       return VANA_EINVAL;
+    }
+}
+
+int isr80h_command6_process_load_start(struct interrupt_frame* frame)
 {
     (void)frame;
     void* filename_user_ptr = task_get_stack_item(task_current(), 0);
@@ -14,7 +28,7 @@ void* isr80h_command6_process_load_start(struct interrupt_frame* frame)
     int res = copy_string_from_task(task_current(), filename_user_ptr, filename, sizeof(filename));
     if (res < 0)
     {
-        return 0;
+        return kernel_to_vana_errno(res);
     }
 
     char path[VANA_MAX_PATH];
@@ -25,7 +39,7 @@ void* isr80h_command6_process_load_start(struct interrupt_frame* frame)
     res = process_load_switch(path, &process);
     if (res < 0)
     {
-        return 0;
+        return kernel_to_vana_errno(res);
     }
 
     task_switch(process->task);
@@ -34,12 +48,12 @@ void* isr80h_command6_process_load_start(struct interrupt_frame* frame)
     return 0;
 }
 
-void* isr80h_command7_invoke_system_command(struct interrupt_frame* frame)
+int isr80h_command7_invoke_system_command(struct interrupt_frame* frame)
 {
     struct command_argument* arguments = task_virtual_address_to_physical(task_current(), task_get_stack_item(task_current(), 0));
     if (!arguments || strlen(arguments[0].argument) == 0)
     {
-        return ERROR(-EINVARG);
+        return VANA_EINVAL;
     }
 
     struct command_argument* root_command_argument = &arguments[0];
@@ -53,13 +67,13 @@ void* isr80h_command7_invoke_system_command(struct interrupt_frame* frame)
     int res = process_load_switch(path, &process);
     if (res < 0)
     {
-        return ERROR(res);
+        return kernel_to_vana_errno(res);
     }
 
     res = process_inject_arguments(process, root_command_argument);
     if (res < 0)
     {
-        return ERROR(res);
+        return kernel_to_vana_errno(res);
     }
 
     task_switch(process->task);
@@ -68,7 +82,7 @@ void* isr80h_command7_invoke_system_command(struct interrupt_frame* frame)
     return 0;
 }
 
-void* isr80h_command8_get_program_arguments(struct interrupt_frame* frame)
+int isr80h_command8_get_program_arguments(struct interrupt_frame* frame)
 {
     struct process* process = task_current()->process;
     struct process_arguments* arguments = task_virtual_address_to_physical(task_current(), task_get_stack_item(task_current(), 0));
@@ -77,7 +91,7 @@ void* isr80h_command8_get_program_arguments(struct interrupt_frame* frame)
     return 0;
 }
 
-void* isr80h_command9_exit(struct interrupt_frame* frame)
+int isr80h_command9_exit(struct interrupt_frame* frame)
 {
     struct process* process = task_current()->process;
     process_terminate(process);

--- a/src/isr80h/process.h
+++ b/src/isr80h/process.h
@@ -3,9 +3,9 @@
 
 struct interrupt_frame;
 
-void* isr80h_command6_process_load_start(struct interrupt_frame* frame);
-void* isr80h_command7_invoke_system_command(struct interrupt_frame* frame);
-void* isr80h_command8_get_program_arguments(struct interrupt_frame* frame);
-void* isr80h_command9_exit(struct interrupt_frame* frame);
+int isr80h_command6_process_load_start(struct interrupt_frame* frame);
+int isr80h_command7_invoke_system_command(struct interrupt_frame* frame);
+int isr80h_command8_get_program_arguments(struct interrupt_frame* frame);
+int isr80h_command9_exit(struct interrupt_frame* frame);
 
 #endif


### PR DESCRIPTION
## Summary
- ensure ISR80h handlers return `int` values
- map kernel error codes to `vana_errno` values
- remove `ERROR()` macro usage

## Testing
- `make all` *(fails: `i686-elf-gcc` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866b46172208324a841b16bf8178f93