### PR TITLE
Fix panic message typo

### DIFF
--- a/src/task/process.c
+++ b/src/task/process.c
@@ -188,7 +188,7 @@ void process_switch_to_any()
     }
 
 
-    panic("No processes to switch too\n");
+    panic("No processes to switch to\n");
 }
 
 static void process_unlink(struct process* process)


### PR DESCRIPTION
## Summary
- fix a typo in process switching panic message

## Testing
- `cd programs/libc && make` *(fails: `i686-elf-gcc: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_6866bae1e4188324aee3c331a0aeab97