### PR TITLE
Fix process task creation error handling

### DIFF
--- a/src/task/process.c
+++ b/src/task/process.c
@@ -533,7 +533,7 @@ int process_load_for_slot(const char* filename, struct process** process, int pr
 
     // Create a task
     _process->task = task_new(_process);
-    if (ERROR_I(_process->task) == 0)
+    if (ISERR(_process->task))
     {
         res = ERROR_I(_process->task);
 


### PR DESCRIPTION
## Summary
- detect errors from `task_new` properly
- cleanup remains on failure

## Testing
- `make all` *(fails: `i686-elf-gcc: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_6866c124609c83248a22b63aa668e368