### PR TITLE
Add interrupt enabled log

### DIFF
--- a/src/kernel.c
+++ b/src/kernel.c
@@ -219,6 +219,7 @@ void kernel_main()
 
     // Enable interrupts and jump straight to the shell task
     enable_interrupts();
+    print("Interrupts on.\n");
     task_switch(process->task);
     task_return(&process->task->registers);
 


### PR DESCRIPTION
## Summary
- log when hardware interrupts are enabled during boot

## Testing
- `./build.sh` *(fails: `i686-elf-gcc: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_6866c4dd13b48324aaff8555fd27f0d7