### PR TITLE
Expose kernel paging chunk symbol

### DIFF
--- a/src/kernel.c
+++ b/src/kernel.c
@@ -20,7 +20,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
-static struct paging_4gb_chunk* kernel_chunk = 0;
+struct paging_4gb_chunk* kernel_chunk = 0;
 
 uint16_t* video_mem = 0;
 uint16_t terminal_row = 0;

--- a/src/kernel.h
+++ b/src/kernel.h
@@ -4,6 +4,9 @@
 #define VGA_WIDTH 80
 #define VGA_HEIGHT 20
 
+#include "memory/paging/paging.h"
+
+extern struct paging_4gb_chunk* kernel_chunk;
 
 void kernel_main();
 void print(const char* str);

--- a/src/task/idle.c
+++ b/src/task/idle.c
@@ -6,7 +6,6 @@
 #include "memory/memory.h"
 #include <stdint.h>
 
-extern struct paging_4gb_chunk* kernel_chunk;
 extern struct task* current_task;
 extern struct task* task_head;
 extern struct task* task_tail;


### PR DESCRIPTION
## Summary
- make the kernel paging chunk globally visible
- declare kernel_chunk in `kernel.h`
- include the header where needed

## Testing
- `bash build.sh` *(fails: `i686-elf-gcc` missing)*

------
https://chatgpt.com/codex/tasks/task_e_6866c7ad45848324bda3067dfc71cfed