### PR TITLE
Pass main return to vana_exit

### DIFF
--- a/programs/stdlib/src/start.asm
+++ b/programs/stdlib/src/start.asm
@@ -8,5 +8,7 @@ section .asm
 
 _start:
     call c_start
+    push eax
     call vana_exit
+    add esp, 4
     ret

--- a/programs/stdlib/src/start.c
+++ b/programs/stdlib/src/start.c
@@ -2,14 +2,11 @@
 
 extern int main(int argc, char** argv);
 
-void c_start()
+int c_start()
 {
     struct process_arguments arguments;
     vana_process_get_arguments(&arguments);
 
     int res = main(arguments.argc, arguments.argv);
-    if (res == 0)
-    {
-        
-    }
+    return res;
 }


### PR DESCRIPTION
## Summary
- return main's result from `c_start`
- push the exit status in `_start` before calling `vana_exit`

## Testing
- `make -C programs/stdlib` *(fails: `i686-elf-gcc` cannot execute `cc1`)*

------
https://chatgpt.com/codex/tasks/task_e_6866cdb2e4388324ba30fbe596a91753