### PR TITLE
Pass exit code via vana_exit syscall

### DIFF
--- a/programs/stdlib/src/start.c
+++ b/programs/stdlib/src/start.c
@@ -8,5 +8,6 @@ int c_start()
     vana_process_get_arguments(&arguments);
 
     int res = main(arguments.argc, arguments.argv);
+    vana_exit(res);
     return res;
 }

--- a/programs/stdlib/src/vana.asm
+++ b/programs/stdlib/src/vana.asm
@@ -112,11 +112,13 @@ vana_process_get_arguments:
     pop ebp
     ret
 
-; void vana_exit()
+; void vana_exit(int status)
 vana_exit:
     push ebp
     mov ebp, esp
     mov eax, 9 ; Command 9 process exit
+    push dword [ebp+8]
     int 0x80
+    add esp, 4
     pop ebp
     ret

--- a/programs/stdlib/src/vana.h
+++ b/programs/stdlib/src/vana.h
@@ -29,6 +29,6 @@ struct command_argument* vana_parse_command(const char* command, int max);
 void vana_process_get_arguments(struct process_arguments* arguments);
 int vana_system(struct command_argument* arguments);
 int vana_system_run(const char* command);
-void vana_exit();
+void vana_exit(int status);
 
 #endif


### PR DESCRIPTION
## Summary
- call `vana_exit` with the result of `main` in `c_start`
- change `vana_exit` to accept an exit status
- document the new prototype in `vana.h`

## Testing
- `make all` *(fails: cannot execute 'cc1')*

------
https://chatgpt.com/codex/tasks/task_e_686731b04f7083249378ee3609211973