### PR TITLE
Add safety checks to build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,19 @@
-#/bin/bash
+#!/bin/bash
+set -e
+
 export PREFIX="$HOME/opt/cross"
 export TARGET=i686-elf
 export PATH="$PREFIX/bin:$PATH"
+
+# Ensure the cross compiler tools exist in PATH
+if ! command -v "$TARGET-gcc" >/dev/null 2>&1; then
+  echo "Error: $TARGET-gcc not found in PATH. Install it or run build-toolchain.sh." >&2
+  exit 1
+fi
+
+if ! command -v "$TARGET-ld" >/dev/null 2>&1; then
+  echo "Error: $TARGET-ld not found in PATH. Install it or run build-toolchain.sh." >&2
+  exit 1
+fi
+
 make all


### PR DESCRIPTION
## Summary
- exit build script on error
- verify cross-toolchain availability before running `make`

## Testing
- `bash build.sh` *(fails: Error: i686-elf-gcc not found in PATH. Install it or run build-toolchain.sh.)*

------
https://chatgpt.com/codex/tasks/task_e_686739b3e51c832498e4c78a94faa526