### PR TITLE
docs: add intro for files reference

### DIFF
--- a/docs/files.md
+++ b/docs/files.md
@@ -1,6 +1,11 @@
 # Source File Overview
 
-The following tables summarize all C and assembly sources under the `src/` tree. Each entry gives a short description of what the file implements.
+This document acts as a guide to the kernel's source tree.  It lists every
+C and assembly file under `src/` so newcomers can quickly locate the code
+responsible for a particular subsystem or feature.
+
+Having a short explanation next to each filename makes navigating the project
+easier when exploring the implementation or adding new functionality.
 
 The list below was verified against `find src -name '*.c' -or -name '*.asm'`
 and currently covers all 33 source files.


### PR DESCRIPTION
## Summary
- add short introduction to `docs/files.md` describing its purpose as a guide to the source tree

## Testing
- `diff -u /tmp/src_list.txt /tmp/doc_list3.txt | head`

------
https://chatgpt.com/codex/tasks/task_e_68676ab4ea108324b449905bef287689