### PR TITLE
docs: annotate isr80h.c

### DIFF
--- a/src/idt/idt.c
+++ b/src/idt/idt.c
@@ -112,6 +112,10 @@ int idt_register_interrupt_callback(int interrupt, INTERRUPT_CALLBACK_FUNCTION c
     interrupt_callbacks[interrupt] = callback;
     return 0;
 }
+/*
+ * Register a system call handler for the given command id.
+ * Panics if the id is invalid or already registered.
+ */
 
 void isr80h_register_command(int command_id, ISR80H_COMMAND command)
 {
@@ -127,6 +131,10 @@ void isr80h_register_command(int command_id, ISR80H_COMMAND command)
 
     isr80h_commands[command_id] = command;
 }
+/*
+ * Look up the handler for a command and execute it.
+ * Returns the handler result or NULL for invalid commands.
+ */
 
 void* isr80h_handle_command(int command, struct interrupt_frame* frame)
 {
@@ -146,6 +154,10 @@ void* isr80h_handle_command(int command, struct interrupt_frame* frame)
     result = func(frame);
     return result;
 }
+/*
+ * Top level ISR for 0x80. Saves task state, dispatches the command and
+ * restores the user page table.
+ */
 
 void* isr80h_handler(int command, struct interrupt_frame* frame)
 {

--- a/src/isr80h/isr80h.c
+++ b/src/isr80h/isr80h.c
@@ -1,3 +1,10 @@
+/*
+ * System call registration for interrupt 0x80.
+ * isr80h_register_commands() populates the global command table
+ * (isr80h_commands in idt.c) with handler functions.
+ * The table holds VANA_MAX_ISR80H_COMMANDS entries indexed by
+ * the enumeration in isr80h.h.
+ */
 #include "isr80h.h"
 #include "idt/idt.h"
 #include "io.h"


### PR DESCRIPTION
## Summary
- document the ISR80h command table and its usage
- add comments for syscall registration and dispatch helpers

## Testing
- `make all` *(fails: cc1 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68676fffa8148324a237789ead5a941b