### PR TITLE
docs: annotate isr80h io.c

### DIFF
--- a/src/isr80h/io.c
+++ b/src/isr80h/io.c
@@ -1,8 +1,22 @@
+
+/*
+ * I/O syscall handlers.
+ *
+ * These functions implement the basic terminal interface exposed through
+ * the `isr80h` system call mechanism. User programs invoke them via
+ * commands 1-3 to print strings, read keyboard input and write single
+ * characters.
+ */
+
 #include "io.h"
 #include "task/task.h"
 #include "keyboard/keyboard.h"
 #include "kernel.h"
 
+/*
+ * Copy a user string from the calling task and print it to the terminal.
+ * The user pointer is expected to be the first item on the stack.
+ */
 void* isr80h_command1_print(struct interrupt_frame* frame)
 {
     (void)frame;
@@ -13,6 +27,10 @@ void* isr80h_command1_print(struct interrupt_frame* frame)
     return 0;
 }
 
+/*
+ * Return the next character from the keyboard queue.
+ * The result is placed in the low byte of eax.
+ */
 void* isr80h_command2_getkey(struct interrupt_frame* frame)
 {
     (void)frame;
@@ -20,6 +38,10 @@ void* isr80h_command2_getkey(struct interrupt_frame* frame)
     return (void*)((int)c);
 }
 
+/*
+ * Write a single character to the terminal using the default color.
+ * The character is passed as the first parameter on the user stack.
+ */
 void* isr80h_command3_putchar(struct interrupt_frame* frame)
 {
     char c = (char)(int)task_get_stack_item(task_current(), 0);


### PR DESCRIPTION
## Summary
- document I/O syscalls in `io.c`
- expand comments for `isr80h_command1_print`, `isr80h_command2_getkey` and `isr80h_command3_putchar`

## Testing
- `make all` *(fails: cannot execute 'cc1')*

------
https://chatgpt.com/codex/tasks/task_e_6867705e34cc832483430d2934970b61