### PR TITLE
docs: annotate elf.c

### DIFF
--- a/src/loader/formats/elf.c
+++ b/src/loader/formats/elf.c
@@ -1,5 +1,13 @@
 #include "elf.h"
 
+/*
+ * elf.c - Basic utilities for working with ELF headers.
+ *
+ * These helpers expose simple accessors for the entry address of an
+ * executable.  Higher level loaders use them when preparing a program
+ * for execution.
+ */
+
 void* elf_get_entry_ptr(struct elf_header* elf_header)
 {
     return (void*) elf_header->e_entry;

--- a/src/loader/formats/elfloader.c
+++ b/src/loader/formats/elfloader.c
@@ -37,21 +37,25 @@ static bool elf_has_program_header(struct elf_header* header)
     return header->e_phoff != 0;
 }
 
+/* Return the pointer to the raw ELF file loaded in memory. */
 void* elf_memory(struct elf_file* file)
 {
     return file->elf_memory;
 }
 
+/* Obtain the main ELF header structure for the loaded file. */
 struct elf_header* elf_header(struct elf_file* file)
 {
     return file->elf_memory;
 }
 
+/* Get the first section header entry from an ELF header. */
 struct elf32_shdr* elf_sheader(struct elf_header* header)
 {
     return (struct elf32_shdr*)((int)header+header->e_shoff);
 }
 
+/* Fetch the first program header or NULL if none exists. */
 struct elf32_phdr* elf_pheader(struct elf_header* header)
 {
     if(header->e_phoff == 0)
@@ -62,41 +66,52 @@ struct elf32_phdr* elf_pheader(struct elf_header* header)
     return (struct elf32_phdr*)((int)header + header->e_phoff);
 }
 
+/* Access the program header at a specific index. */
 struct elf32_phdr* elf_program_header(struct elf_header* header, int index)
 {
     return &elf_pheader(header)[index];
 }
 
+/* Access the section header at a specific index. */
 struct elf32_shdr* elf_section(struct elf_header* header, int index)
 {
     return &elf_sheader(header)[index];
 }
 
+/* Translate a program header offset to a physical address. */
 void* elf_phdr_phys_address(struct elf_file* file, struct elf32_phdr* phdr)
 {
     return elf_memory(file)+phdr->p_offset;
 }
 
+/*
+ * Return a pointer to the section header string table containing
+ * the names of all sections.
+ */
 char* elf_str_table(struct elf_header* header)
 {
     return (char*) header + elf_section(header, header->e_shstrndx)->sh_offset;
 }
 
+/* Virtual address at which the ELF image is mapped. */
 void* elf_virtual_base(struct elf_file* file)
 {
     return file->virtual_base_address;
 }
 
+/* Last virtual address occupied by the ELF mapping. */
 void* elf_virtual_end(struct elf_file* file)
 {
     return file->virtual_end_address;
 }
 
+/* Physical start of the loaded ELF image. */
 void* elf_phys_base(struct elf_file* file)
 {
     return file->physical_base_address;
 }
 
+/* Physical end address of the ELF allocation. */
 void* elf_phys_end(struct elf_file* file)
 {
     return file->physical_end_address;

--- a/src/loader/formats/elfloader.h
+++ b/src/loader/formats/elfloader.h
@@ -45,17 +45,28 @@ struct elf_file* elf_file_new();
 void elf_file_free(struct elf_file* file);
 
 void elf_close(struct elf_file* file);
+/* Starting virtual address of the loaded ELF image. */
 void* elf_virtual_base(struct elf_file* file);
+/* Virtual address where the ELF image ends. */
 void* elf_virtual_end(struct elf_file* file);
+/* Starting physical address of the loaded ELF image. */
 void* elf_phys_base(struct elf_file* file);
+/* Final physical address used by the ELF image. */
 void* elf_phys_end(struct elf_file* file);
 
+/* Get a pointer to the ELF header within the file. */
 struct elf_header* elf_header(struct elf_file* file);
+/* Return the first section header entry. */
 struct elf32_shdr* elf_sheader(struct elf_header* header);
+/* Pointer to the raw ELF data in memory. */
 void* elf_memory(struct elf_file* file);
+/* Return the first program header entry. */
 struct elf32_phdr* elf_pheader(struct elf_header* header);
+/* Retrieve the program header at the given index. */
 struct elf32_phdr* elf_program_header(struct elf_header* header, int index);
+/* Retrieve the section header at the given index. */
 struct elf32_shdr* elf_section(struct elf_header* header, int index);
+/* Convert a program header into a physical address. */
 void* elf_phdr_phys_address(struct elf_file* file, struct elf32_phdr* phdr);
 
 #endif


### PR DESCRIPTION
## Summary
- add explanatory header to `elf.c`
- document helpers that return ELF addresses and sections

## Testing
- `make clean`
- `make -s all` *(fails: cannot execute 'cc1')*

------
https://chatgpt.com/codex/tasks/task_e_68677aafe52883248b5d11fa57cc6c7a