### PR TITLE
docs: annotate elfloader.c

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -26,6 +26,7 @@ Below is a table of all available topics.
 | [syscalls.md](syscalls.md) | System Calls |
 | [fat16.md](fat16.md) | FAT16 Filesystem Overview |
 | [scheduler.md](scheduler.md) | Task Scheduler |
+| [elf_loading.md](elf_loading.md) | ELF Loader and Paging Setup |
 | [files.md](files.md) | Source File Overview |
 
 For a high level introduction see the [project README](../README.md).

--- a/docs/elf_loading.md
+++ b/docs/elf_loading.md
@@ -1,0 +1,15 @@
+# ELF Loader and Paging Setup
+
+The kernel supports running user programs stored as ELF executables. Loading an ELF file consists of reading the file into memory, validating the header and mapping each program segment into a task's address space. The paging layer then ensures those virtual addresses point at the loaded data with the appropriate permissions.
+
+## Loading and Validation
+
+`elf_load()` opens the file, allocates a buffer and reads the entire contents. It checks the ELF signature, class, data encoding and that a program header exists. Only 32‑bit little‑endian executables are accepted. Each program header is processed so the loader knows the required virtual and physical ranges.
+
+## Mapping Segments
+
+When `process_map_memory()` runs for an ELF process, it walks the program headers recorded by `elf_load()`. For every `PT_LOAD` entry the pages backing the segment are mapped into the task's directory with `paging_map_to()`. Writeable segments receive the `PAGING_IS_WRITEABLE` flag while read‑only sections are left protected.
+
+The program's entry point comes from the ELF header (`e_entry`). The task's stack is mapped at `VANA_PROGRAM_VIRTUAL_STACK_ADDRESS_END` and grows downward. Because each task starts from the kernel's 4 GB identity mapping, the kernel remains accessible while user code resides at `VANA_PROGRAM_VIRTUAL_ADDRESS` and above.
+
+Together this process ensures ELF executables appear at the correct virtual addresses and can safely transition into user mode.

--- a/src/loader/formats/elfloader.c
+++ b/src/loader/formats/elfloader.c
@@ -173,6 +173,7 @@ out:
     return res;
 }
 
+// Release the memory associated with an ELF file structure.
 void elf_file_free(struct elf_file* elf_file)
 {
     if (elf_file->elf_memory)
@@ -183,11 +184,14 @@ void elf_file_free(struct elf_file* elf_file)
     kfree(elf_file);
 }
 
+// Allocate a new ELF file structure with all fields zeroed.
 struct elf_file* elf_file_new()
 {
     return (struct elf_file*)kzalloc(sizeof(struct elf_file));
 }
 
+// Load an ELF executable from disk into memory and validate its headers.
+// On success `*file_out` receives the allocated `struct elf_file` instance.
 int elf_load(const char* filename, struct elf_file** file_out)
 {
     struct elf_file* elf_file = elf_file_new();


### PR DESCRIPTION
## Summary
- document ELF loader and paging setup
- include new ELF documentation in the docs index
- add explanatory comments to `elf_file_new` and `elf_load`

## Testing
- `make all` *(fails: cannot execute 'cc1')*

------
https://chatgpt.com/codex/tasks/task_e_68677aba02e48324a1b64a7c99c047a5