### PR TITLE
Add calloc to libc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,11 +47,13 @@ dirs:
 	mkdir -p $(BUILD_DIRS)
 
 user_programs:
+	cd ./programs/libc && $(MAKE)
 	cd ./programs/stdlib && $(MAKE)
 	cd ./programs/blank && $(MAKE)
 	cd ./programs/shell && $(MAKE)
 
 user_programs_clean:
+	- cd ./programs/libc && $(MAKE) clean
 	- cd ./programs/stdlib && $(MAKE) clean
 	- cd ./programs/blank && $(MAKE) clean
 	- cd ./programs/shell && $(MAKE) clean

--- a/programs/libc/Makefile
+++ b/programs/libc/Makefile
@@ -1,0 +1,32 @@
+BUILD_DIR=./build
+INCLUDES=-I./include
+FLAGS=-g -ffreestanding -fno-builtin -Wall -O0 -nostdlib -nostartfiles -nodefaultlibs
+
+FILES=\
+$(BUILD_DIR)/startup/crt0.o \
+$(BUILD_DIR)/sys_wrappers.o \
+$(BUILD_DIR)/heap/malloc.o \
+$(BUILD_DIR)/heap/free.o \
+$(BUILD_DIR)/heap/realloc.o \
+$(BUILD_DIR)/heap/calloc.o \
+$(BUILD_DIR)/string/memset.o \
+$(BUILD_DIR)/string/memcpy.o \
+$(BUILD_DIR)/string/strcmp.o \
+$(BUILD_DIR)/string/strlen.o
+
+all: $(BUILD_DIR) $(FILES)
+	i686-elf-ld -m elf_i386 -relocatable $(FILES) -o $(BUILD_DIR)/libc.o
+
+$(BUILD_DIR):
+	mkdir -p $(BUILD_DIR)/heap $(BUILD_DIR)/string $(BUILD_DIR)/startup
+
+$(BUILD_DIR)/startup/%.o: startup/%.s | $(BUILD_DIR)
+	i686-elf-gcc $(FLAGS) -c $< -o $@ -Wa,--32
+
+$(BUILD_DIR)/%.o: %.c | $(BUILD_DIR)
+	i686-elf-gcc $(INCLUDES) $(FLAGS) -std=gnu99 -c $< -o $@
+
+clean:
+	rm -rf $(BUILD_DIR)
+
+.PHONY: all clean

--- a/programs/libc/heap/calloc.c
+++ b/programs/libc/heap/calloc.c
@@ -1,0 +1,14 @@
+#include "../include/stdlib.h"
+#include "../include/string.h"
+
+void *calloc(size_t nmemb, size_t size)
+{
+    if (size != 0 && nmemb > SIZE_MAX / size)
+        return (void*)0;
+
+    size_t total = nmemb * size;
+    void *ptr = malloc(total);
+    if (ptr)
+        memset(ptr, 0, total);
+    return ptr;
+}

--- a/programs/libc/include/stdlib.h
+++ b/programs/libc/include/stdlib.h
@@ -5,5 +5,6 @@
 void *malloc(size_t size);
 void free(void *ptr);
 void *realloc(void *ptr, size_t size);
+void *calloc(size_t nmemb, size_t size);
 
 #endif


### PR DESCRIPTION
## Summary
- implement `calloc` for the minimal libc
- compile calloc into libc build via new Makefile
- build libc as part of the main Makefile

## Testing
- `make -C programs/libc` *(fails: cannot execute `cc1`)*
- `make all` *(fails: cannot execute `cc1`)*

------
https://chatgpt.com/codex/tasks/task_e_686888b017648324a6ae8b2d280813ea