### PR TITLE
Document kernel init functions

### DIFF
--- a/src/gdt/gdt.c
+++ b/src/gdt/gdt.c
@@ -1,15 +1,20 @@
-/*
- * gdt.c - encode and install Global Descriptor Table entries
+/**
+ * @file gdt.c
+ * @brief Encode and install Global Descriptor Table entries.
  *
- * The kernel describes segments using struct gdt_structured.
- * encode_gdt_entry converts each structured entry into the packed
- * 8-byte format required by the CPU, setting limit granularity and
- * base fields. gdt_structured_to_gdt iterates over an array of
- * structured entries and produces the final table ready for gdt_load.
+ * The kernel describes segments using struct gdt_structured. Each entry is
+ * converted into the packed 8-byte format required by the CPU before being
+ * loaded with gdt_load.
  */
 #include "gdt.h"
 #include "kernel.h"
 
+/**
+ * Encode a structured GDT descriptor into its binary form.
+ *
+ * @param target  Pointer to the 8-byte entry to fill in.
+ * @param source  Human friendly representation containing base, limit and type.
+ */
 static void encode_gdt_entry(uint8_t* target, struct gdt_structured source)
 {
     if ((source.limit > 65536) && ((source.limit & 0xFFF) != 0xFFF))
@@ -42,7 +47,9 @@ static void encode_gdt_entry(uint8_t* target, struct gdt_structured source)
  * @param total_entries   Number of entries in the array.
  */
 
-void gdt_structured_to_gdt(struct gdt* gdt, struct gdt_structured* structured_gdt, int total_entries)
+void gdt_structured_to_gdt(struct gdt* gdt,
+                           struct gdt_structured* structured_gdt,
+                           int total_entries)
 {
     for (int i = 0; i < total_entries; i++)
     {

--- a/src/gdt/gdt.h
+++ b/src/gdt/gdt.h
@@ -31,13 +31,13 @@ struct gdt_descriptor
 } __attribute__((packed));
 
 /**
- * Load the Global Descriptor Table described by `descriptor`.
- * Reloads all segment registers to make the new table active.
+ * Load the Global Descriptor Table and make it the active descriptor set.
  */
 void gdt_load(struct gdt_descriptor* descriptor);
 /**
- * Encode an array of `struct gdt_structured` into raw descriptors.
+ * Convert an array of structured descriptors into packed form ready for gdt_load.
  */
-void gdt_structured_to_gdt(struct gdt* gdt, struct gdt_structured* structured_gdt, int total_entries);
+void gdt_structured_to_gdt(struct gdt* gdt, struct gdt_structured* structured_gdt,
+                           int total_entries);
 
 #endif

--- a/src/idt/idt.h
+++ b/src/idt/idt.h
@@ -50,13 +50,22 @@ struct interrupt_frame
     uint32_t ss;
 } __attribute__((packed));
 
+/** Set up the IDT and load it into the CPU. */
 void idt_init();
+/** Enable maskable CPU interrupts with the STI instruction. */
 void enable_interrupts();
+/** Disable maskable CPU interrupts with the CLI instruction. */
 void disable_interrupts();
+/** Register a new system call handler for INT 0x80. */
 void isr80h_register_command(int command_id, ISR80H_COMMAND command);
+/** Invoke a previously registered system call handler. */
 void* isr80h_handle_command(int command, struct interrupt_frame* frame);
+/** Assembly entry point wrapper for system calls. */
 void* isr80h_handler(int command, struct interrupt_frame* frame);
-int idt_register_interrupt_callback(int interrupt, INTERRUPT_CALLBACK_FUNCTION interrupt_callback);
+/** Register a callback for a specific interrupt vector. */
+int idt_register_interrupt_callback(int interrupt,
+                                    INTERRUPT_CALLBACK_FUNCTION interrupt_callback);
+/** Simple handler that acknowledges and ignores an interrupt. */
 void interrupt_ignore(struct interrupt_frame* frame);
 
 #endif

--- a/src/kernel.h
+++ b/src/kernel.h
@@ -5,11 +5,17 @@
 #define VGA_HEIGHT 20
 
 
+/** Entry point after the bootloader hands control to the kernel. */
 void kernel_main();
+/** Write a string directly to the VGA text console. */
 void print(const char* str);
+/** Display a panic message and halt. */
 void panic(const char* msg);
+/** Switch to the kernel's page directory. */
 void kernel_page();
+/** Restore segment registers for kernel mode. */
 void kernel_registers();
+/** Low level helper to output a single character with colour. */
 void terminal_writechar(char c, char colour);
 
 #define ERROR(value)  ((void*)(value))

--- a/src/pic/pic.c
+++ b/src/pic/pic.c
@@ -1,18 +1,22 @@
 #include "pic.h"
 #include "io/io.h"
 
-/*
- * pic.c - Basic helpers for the Programmable Interrupt Controller.
+/**
+ * @file pic.c
+ * @brief Helpers for interacting with the Programmable Interrupt Controller.
  *
- * During early boot the master and slave PICs are remapped in
- * `kernel.asm` so hardware IRQs use vectors 0x20-0x2F. All lines are
- * initially masked. Once an interrupt is handled an End Of Interrupt
- * (EOI) command must be sent to the controller. For IRQs delivered by
- * the slave both PICs must receive an EOI.
-*/
+ * The PIC is remapped during early boot so that hardware IRQs begin at vector
+ * 0x20. Each interrupt must be acknowledged with an End Of Interrupt command.
+ * If the interrupt originated from the slave (IRQs 8-15) both PICs require an
+ * acknowledgement.
+ */
 
-// Send an EOI to the PICs for the specified IRQ number.
-// IRQs >= 8 originate from the slave and require acknowledging both chips.
+/**
+ * Send an End Of Interrupt command to the PICs.
+ *
+ * @param irq The IRQ number being acknowledged. IRQs >= 8 originate from the
+ *            slave controller and therefore both controllers must be updated.
+ */
 void pic_send_eoi(int irq)
 {
     if (irq >= 8)

--- a/src/pic/pic.h
+++ b/src/pic/pic.h
@@ -7,6 +7,7 @@
 #define PIC2_DATA 0xA1
 #define PIC_EOI 0x20
 
+/** Notify the PIC that the specified IRQ has been handled. */
 void pic_send_eoi(int irq);
 
 #endif

--- a/src/string/string.c
+++ b/src/string/string.c
@@ -1,15 +1,20 @@
 #include "string.h"
 
-/*
- * Minimal string utility routines used throughout the kernel.  These
- * helpers implement common libc functionality such as measuring string
- * length and copying buffers without relying on the host C library.
- * The primitives here are shared by both kernel and user space code.
+/**
+ * @file string.c
+ * @brief Minimal C string helpers used by the kernel and user programs.
+ *
+ * The kernel cannot rely on the host C library, so a subset of standard
+ * routines are reimplemented here. They are lightweight but compatible with the
+ * usual libc counterparts.
  */
 
-/*
- * Convert an uppercase ASCII character to lowercase.  Characters
- * outside the A-Z range are returned unchanged.
+/**
+ * Convert an uppercase ASCII character to lowercase.
+ *
+ * Characters outside the 'A'-'Z' range are returned unchanged. This helper is
+ * used when implementing case-insensitive string comparisons within the
+ * kernel.
  */
 char tolower(char s1)
 {
@@ -21,9 +26,11 @@ char tolower(char s1)
     return s1;
 }
 
-/*
- * Return the length of a NUL terminated string.  This avoids relying
- * on the host implementation of strlen.
+/**
+ * Calculate the length of a NUL terminated string.
+ *
+ * Implemented so the kernel does not rely on the host's libc. Returns the
+ * number of characters before the NUL byte.
  */
 int strlen(const char* ptr)
 {
@@ -37,9 +44,11 @@ int strlen(const char* ptr)
     return i;
 }
 
-/*
- * Bounded string length.  Scan at most max bytes looking for the
- * terminating NUL and return the number of characters seen.
+/**
+ * Return the length of a string but scan at most `max` bytes.
+ *
+ * This guards against reading beyond the provided buffer when a NUL terminator
+ * may be missing. The count returned excludes the NUL if found.
  */
 int strnlen(const char* ptr, int max)
 {
@@ -53,9 +62,11 @@ int strnlen(const char* ptr, int max)
     return i;
 }
 
-/*
- * Variant of strnlen that also stops at the provided terminator
- * character in addition to a NUL byte.
+/**
+ * Version of strnlen that also stops at a custom terminator.
+ *
+ * Useful when parsing path strings where components are separated by a
+ * specific character. Scans no more than `max` bytes.
  */
 int strnlen_terminator(const char* str, int max, char terminator)
 {
@@ -69,9 +80,11 @@ int strnlen_terminator(const char* str, int max, char terminator)
     return i;
 }
 
-/*
- * Case-insensitive string compare of at most n characters.
- * Differences are returned similarly to strncmp.
+/**
+ * Compare two strings ignoring case for at most `n` characters.
+ *
+ * Differences are returned in the same fashion as strncmp. This is used by the
+ * filesystem to compare path components in a case-insensitive manner.
  */
 int istrncmp(const char* s1, const char* s2, int n)
 {
@@ -92,6 +105,12 @@ int istrncmp(const char* s1, const char* s2, int n)
  * Compare two strings for at most n characters and return
  * the difference of the first mismatching byte.
  */
+/**
+ * Compare two strings for at most `n` characters.
+ *
+ * Returns the difference between the first mismatching bytes. Used throughout
+ * the kernel when parsing configuration strings and file names.
+ */
 int strncmp(const char* str1, const char* str2, int n)
 {
     unsigned char u1, u2;
@@ -109,9 +128,11 @@ int strncmp(const char* str1, const char* str2, int n)
     return 0;
 }
 
-/*
- * Copy the NUL terminated string src into dest.  The destination
- * buffer must be large enough to hold the entire source string.
+/**
+ * Copy a NUL terminated string into the destination buffer.
+ *
+ * The caller must ensure `dest` is large enough. Used heavily by the loader
+ * and filesystem code when constructing paths and messages.
  */
 char* strcpy(char* dest, const char* src)
 {
@@ -128,9 +149,11 @@ char* strcpy(char* dest, const char* src)
     return res;
 }
 
-/*
- * Copy at most count-1 characters from src into dest and always
- * NUL terminate the destination buffer.
+/**
+ * Safe string copy with explicit length.
+ *
+ * Copies up to `count-1` characters and always terminates `dest` with a NUL
+ * byte. This avoids buffer overruns when handling user supplied data.
  */
 char* strncpy(char* dest, const char* src, int count)
 {
@@ -148,19 +171,27 @@ char* strncpy(char* dest, const char* src, int count)
 }
 
 /* Return true if the ASCII character c is a decimal digit. */
+/**
+ * Check if a character is an ASCII decimal digit.
+ */
 bool isdigit(char c)
 {
     return c >= 48 && c <= 57;
 }
 /* Convert an ASCII digit to its numeric value. */
+/**
+ * Convert an ASCII digit into its numeric value.
+ */
 int tonumericdigit(char c)
 {
     return c - 48;
 }
 
-/*
- * Convert an integer value to its decimal string representation.
- * The output buffer must be large enough to hold the result.
+/**
+ * Convert an integer value to a decimal string.
+ *
+ * The output buffer must be large enough to hold the resulting digits and NUL
+ * terminator. Used primarily for debug output.
  */
 void int_to_string(int value, char* out)
 {

--- a/src/string/string.h
+++ b/src/string/string.h
@@ -3,16 +3,27 @@
 
 #include <stdbool.h>
 
+/** Return the length of a NUL terminated string. */
 int strlen(const char* ptr);
+/** Bounded string length that scans at most `max` bytes. */
 int strnlen(const char* ptr, int max);
+/** True if the character is 0-9. */
 bool isdigit(char c);
+/** Convert an ASCII digit into its numeric value. */
 int tonumericdigit(char c);
+/** Copy a NUL terminated string into dest. */
 char* strcpy(char* dest, const char* src);
+/** Length limited string copy that always NUL terminates. */
 char* strncpy(char* dest, const char* src, int count);
+/** Compare two strings up to `n` characters. */
 int strncmp(const char* str1, const char* str2, int n);
+/** Case-insensitive string compare for at most `n` chars. */
 int istrncmp(const char* s1, const char* s2, int n);
+/** Like strnlen but stops at the terminator character as well. */
 int strnlen_terminator(const char* str, int max, char terminator);
+/** Convert an uppercase ASCII character to lowercase. */
 char tolower(char s1);
+/** Convert an integer to a decimal string. */
 void int_to_string(int value, char* out);
 
 #endif


### PR DESCRIPTION
## Summary
- document kernel console and startup helpers
- annotate GDT, IDT and PIC routines
- clarify string helper utilities
- add API comments in headers

## Testing
- `make all` *(fails: cannot execute 'cc1')*

------
https://chatgpt.com/codex/tasks/task_e_686d6afd04c48324acbd049d32c4f725