### PR TITLE
Allow build-toolchain to build 64-bit cross toolchain

### DIFF
--- a/build-toolchain.sh
+++ b/build-toolchain.sh
@@ -1,15 +1,20 @@
 #!/bin/bash
 set -e
 
+# Usage:
+#   ./build-toolchain.sh         # builds an i686-elf toolchain
+#   TARGET=x86_64-elf ./build-toolchain.sh
+
 export PREFIX="$HOME/opt/cross"
-export TARGET=i686-elf
+export TARGET="${TARGET:-i686-elf}"
 export PATH="$PREFIX/bin:$PATH"
 export BINVER="2.38"
 export GCCVER="12.3.0"
 
 # create and enter our source tree
-mkdir -p "$HOME/source/x86"
-cd "$HOME/source/x86"
+SRCDIR="$HOME/source/$TARGET"
+mkdir -p "$SRCDIR"
+cd "$SRCDIR"
 
 # install prerequisites
 sudo apt-get update
@@ -50,7 +55,7 @@ make install
 #
 # 2) build & install GCC (C and C++)
 #
-cd "$HOME/source/x86"     # back to the source root
+cd "$SRCDIR"     # back to the source root
 mkdir -p build-gcc
 cd build-gcc
 


### PR DESCRIPTION
## Summary
- parameterize build-toolchain.sh to accept TARGET env var
- document usage for x86_64-elf target
- isolate source directories per target

## Testing
- `bash -n build-toolchain.sh`

------
https://chatgpt.com/codex/tasks/task_e_68965a61cbf88324bf8270a0f4d81cc3