### PR TITLE
Add 64-bit linker script

### DIFF
--- a/src/linker64.ld
+++ b/src/linker64.ld
@@ -1,14 +1,53 @@
 OUTPUT_FORMAT("elf64-x86-64")
 ENTRY(_start)
+
+KERNEL_PHYS = 1M;
+KERNEL_VMA = 0xffffffff80000000;
+_phys_to_virt_offset = KERNEL_VMA - KERNEL_PHYS;
+
+PHDRS
+{
+    text   PT_LOAD FLAGS(5);
+    rodata PT_LOAD FLAGS(4);
+    data   PT_LOAD FLAGS(6);
+}
+
 SECTIONS
 {
-    . = 1M;
-    .text : ALIGN(4096) { *(.text) }
-    .rodata : ALIGN(4096) { *(.rodata) }
-    .data : ALIGN(4096) { *(.data) }
-    .bss : ALIGN(4096) {
+    . = KERNEL_VMA;
+    _kernel_start = .;
+
+    .text : ALIGN(0x1000) AT(KERNEL_PHYS)
+    {
+        _text = .;
+        *(.text*)
+        _etext = .;
+    } :text
+
+    .rodata : ALIGN(0x1000) AT(KERNEL_PHYS + (ADDR(.rodata) - KERNEL_VMA))
+    {
+        *(.rodata*)
+    } :rodata
+
+    .data : ALIGN(0x1000) AT(KERNEL_PHYS + (ADDR(.data) - KERNEL_VMA))
+    {
+        _data = .;
+        *(.data*)
+        _edata = .;
+    } :data
+
+    .bss : ALIGN(0x1000) (NOLOAD) AT(KERNEL_PHYS + (ADDR(.bss) - KERNEL_VMA))
+    {
+        _bss = .;
         *(COMMON)
-        *(.bss)
-    }
-    .asm : ALIGN(4096) { *(.asm) }
+        *(.bss*)
+        _ebss = .;
+    } :data
+
+    .asm : ALIGN(0x1000) AT(KERNEL_PHYS + (ADDR(.asm) - KERNEL_VMA))
+    {
+        *(.asm*)
+    } :text
+
+    _kernel_end = .;
 }


### PR DESCRIPTION
## Summary
- add higher-half 64-bit linker script targeting ELF64
- define load and virtual addresses with exported kernel symbols

## Testing
- `make vana64` *(fails: i686-elf-gcc: fatal error: cannot execute 'cc1')*
- `make bin/kernel.bin` *(fails: i686-elf-gcc: fatal error: cannot execute 'cc1')*

------
https://chatgpt.com/codex/tasks/task_e_689662f2504c8324a03d0c4cc51e3d50