### PR TITLE
Add 64-bit kernel entry stub and build rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -207,8 +207,13 @@ vana64: dirs bin/boot64.bin bin/kernel64.bin
 build/kernel64.o: src/kernel64.c
 	$(CC) $(KERNEL_CFLAGS) -c $< -o $@
 
-bin/kernel64.bin: build/kernel64.o
-	$(LD) $(LDFLAGS) build/kernel64.o -o bin/kernel64.bin
+ifeq ($(ARCH),x86_64)
+build/kernel64.asm.o: src/kernel64.asm
+	nasm -f elf64 -g src/kernel64.asm -o build/kernel64.asm.o
+
+bin/kernel64.bin: build/kernel64.asm.o build/kernel64.o
+	$(LD) $(LDFLAGS) build/kernel64.asm.o build/kernel64.o -o bin/kernel64.bin
+endif
 
 build/boot64/boot.o: src/boot64/boot.asm
 	nasm -f elf32 -g src/boot64/boot.asm -o build/boot64/boot.o

--- a/src/kernel64.asm
+++ b/src/kernel64.asm
@@ -1,0 +1,39 @@
+[BITS 64]
+
+global _start
+extern kernel_main
+
+gdt64:
+    dq 0                      ; Null descriptor
+    dq 0x00af9a000000ffff     ; 64-bit code segment
+    dq 0x00af92000000ffff     ; 64-bit data segment
+
+gdtr:
+    dw gdtr_end - gdt64 - 1
+    dq gdt64
+
+_start:
+    lgdt [gdtr]
+
+    lea rax, [rel .reload_cs]
+    push 0x08
+    push rax
+    retfq
+.reload_cs:
+    xor eax, eax
+    mov ds, ax
+    mov es, ax
+    mov ss, ax
+    mov fs, ax
+    mov gs, ax
+
+    mov rsp, 0xffffffff80000000 + 0x200000
+    mov rbp, rsp
+
+    call kernel_main
+
+.hang:
+    hlt
+    jmp .hang
+
+gdtr_end:

--- a/src/kernel64.c
+++ b/src/kernel64.c
@@ -1,1 +1,2 @@
-void _start(void) {}
+void kernel_main(void) {
+}


### PR DESCRIPTION
## Summary
- add long-mode entry stub that loads a 64-bit GDT, sets a high stack, zeroes segments, and calls `kernel_main`
- compile the new assembly only for `ARCH=x86_64`
- stub out `kernel_main` for the 64-bit kernel

## Testing
- `make ARCH=x86_64 vana64` *(fails: `x86_64-elf-ld: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_6896c17f4f4c83249eb5ae04738d3d42