### PR TITLE
Add 64-bit GDT setup

### DIFF
--- a/src/gdt/gdt.h
+++ b/src/gdt/gdt.h
@@ -7,6 +7,11 @@
 #define GDT_KERNEL_DATA_SELECTOR 0x10
 #define GDT_TSS_SELECTOR 0x28
 
+/* 64-bit segment selectors */
+#define GDT64_KERNEL_CODE_SELECTOR 0x08
+#define GDT64_KERNEL_DATA_SELECTOR 0x10
+#define GDT64_TSS_SELECTOR 0x18
+
 struct gdt
 {
     uint16_t segment;
@@ -30,6 +35,12 @@ struct gdt_descriptor
     uint32_t address;
 } __attribute__((packed));
 
+struct gdt64_descriptor
+{
+    uint16_t size;
+    uint64_t address;
+} __attribute__((packed));
+
 /**
  * Load the Global Descriptor Table and make it the active descriptor set.
  */
@@ -39,5 +50,7 @@ void gdt_load(struct gdt_descriptor* descriptor);
  */
 void gdt_structured_to_gdt(struct gdt* gdt, struct gdt_structured* structured_gdt,
                            int total_entries);
+
+void gdt64_init(void);
 
 #endif

--- a/src/gdt/gdt64.asm
+++ b/src/gdt/gdt64.asm
@@ -1,0 +1,19 @@
+[BITS 64]
+
+section .asm
+
+global gdt64
+global gdt64_descriptor
+
+gdt64:
+    dq 0                        ; Null descriptor
+    dq 0x00af9a000000ffff       ; 64-bit code segment
+    dq 0x00af92000000ffff       ; 64-bit data segment
+    dq 0                        ; TSS descriptor (low 8 bytes)
+    dq 0                        ; TSS descriptor (high 8 bytes)
+
+gdt64_end:
+
+gdt64_descriptor:
+    dw gdt64_end - gdt64 - 1
+    dq gdt64

--- a/src/gdt/gdt64.c
+++ b/src/gdt/gdt64.c
@@ -1,0 +1,12 @@
+/**
+ * @file gdt64.c
+ * @brief Install the 64-bit Global Descriptor Table.
+ */
+
+#include "gdt.h"
+
+void gdt64_init(void)
+{
+    extern struct gdt64_descriptor gdt64_descriptor;
+    __asm__ volatile("lgdt %0" : : "m"(gdt64_descriptor));
+}


### PR DESCRIPTION
## Summary
- define 64-bit GDT with code, data, and TSS descriptors
- add initializer to load the 64-bit GDT
- expose 64-bit selectors and init prototype in GDT headers

## Testing
- `make vana64 ARCH=x86_64` *(fails: x86_64-elf-ld: No such file or directory)*
- `make build/gdt.o` *(fails: i686-elf-gcc: fatal error: cannot execute 'cc1')*

------
https://chatgpt.com/codex/tasks/task_e_6896d852f9048324aa5b0097e8e28dfb