### PR TITLE
Add basic 64-bit paging support

### DIFF
--- a/src/kernel64.c
+++ b/src/kernel64.c
@@ -1,2 +1,11 @@
-void kernel_main(void) {
+#include <stdint.h>
+#include "memory/paging/paging64.h"
+
+#define HHDM_BASE 0xffff800000000000ULL
+#define DIRECT_MAP_PAGES (1024*1024) /* map first 1 GiB */
+
+void kernel_main(void)
+{
+    paging64_init(HHDM_BASE);
+    map_range(HHDM_BASE, 0, DIRECT_MAP_PAGES, PTE_RW | PTE_NX);
 }

--- a/src/memory/paging/paging64.c
+++ b/src/memory/paging/paging64.c
@@ -1,0 +1,142 @@
+#include "paging64.h"
+
+static uint64_t hhdm_offset = 0;
+static uint64_t next_free_phys = 0x200000; /* start at 2 MiB for tables */
+static pte_t* pml4 = 0;
+
+static uint64_t alloc_page_phys(void)
+{
+    uint64_t phys = next_free_phys;
+    next_free_phys += PAGE_SIZE;
+    /* zero memory via direct map */
+    uint64_t* ptr = (uint64_t*)phys_to_virt(phys);
+    for (size_t i = 0; i < PAGE_SIZE / sizeof(uint64_t); i++)
+        ptr[i] = 0;
+    return phys;
+}
+
+static pte_t* alloc_table(void)
+{
+    uint64_t phys = alloc_page_phys();
+    return (pte_t*)phys_to_virt(phys);
+}
+
+static inline uint64_t rdmsr(uint32_t msr)
+{
+    uint32_t low, high;
+    __asm__ volatile("rdmsr" : "=a"(low), "=d"(high) : "c"(msr));
+    return ((uint64_t)high << 32) | low;
+}
+
+static inline void wrmsr(uint32_t msr, uint64_t val)
+{
+    uint32_t low = (uint32_t)val;
+    uint32_t high = (uint32_t)(val >> 32);
+    __asm__ volatile("wrmsr" :: "c"(msr), "a"(low), "d"(high));
+}
+
+void paging64_init(uint64_t hhdm_base)
+{
+    hhdm_offset = hhdm_base;
+    pml4 = alloc_table();
+
+    /* Load PML4 into CR3 */
+    uint64_t cr3 = virt_to_phys((uint64_t)pml4);
+    __asm__ volatile("mov %0, %%cr3" :: "r"(cr3));
+
+    /* Enable NXE */
+    uint64_t efer = rdmsr(0xC0000080);
+    efer |= (1ull << 11); /* NXE */
+    wrmsr(0xC0000080, efer);
+}
+
+uint64_t phys_to_virt(uint64_t phys)
+{
+    if (!hhdm_offset)
+        return phys;
+    return phys + hhdm_offset;
+}
+
+uint64_t virt_to_phys(uint64_t virt)
+{
+    if (hhdm_offset && virt >= hhdm_offset)
+        return virt - hhdm_offset;
+
+    uint16_t pml4_i = (virt >> 39) & 0x1FF;
+    uint16_t pdpt_i = (virt >> 30) & 0x1FF;
+    uint16_t pd_i   = (virt >> 21) & 0x1FF;
+    uint16_t pt_i   = (virt >> 12) & 0x1FF;
+
+    if (!(pml4[pml4_i] & PTE_P))
+        return 0;
+    pte_t* pdpt = (pte_t*)phys_to_virt(pml4[pml4_i] & 0x000ffffffffff000ULL);
+    if (!(pdpt[pdpt_i] & PTE_P))
+        return 0;
+    pte_t* pd = (pte_t*)phys_to_virt(pdpt[pdpt_i] & 0x000ffffffffff000ULL);
+    if (!(pd[pd_i] & PTE_P))
+        return 0;
+    pte_t* pt = (pte_t*)phys_to_virt(pd[pd_i] & 0x000ffffffffff000ULL);
+    pte_t entry = pt[pt_i];
+    if (!(entry & PTE_P))
+        return 0;
+    return (entry & 0x000ffffffffff000ULL) | (virt & 0xFFF);
+}
+
+int map_page(uint64_t virt, uint64_t phys, uint64_t flags)
+{
+    uint16_t pml4_i = (virt >> 39) & 0x1FF;
+    uint16_t pdpt_i = (virt >> 30) & 0x1FF;
+    uint16_t pd_i   = (virt >> 21) & 0x1FF;
+    uint16_t pt_i   = (virt >> 12) & 0x1FF;
+
+    if (!(pml4[pml4_i] & PTE_P)) {
+        pte_t* new_pdpt = alloc_table();
+        pml4[pml4_i] = virt_to_phys((uint64_t)new_pdpt) | PTE_P | PTE_RW;
+    }
+    pte_t* pdpt = (pte_t*)phys_to_virt(pml4[pml4_i] & 0x000ffffffffff000ULL);
+
+    if (!(pdpt[pdpt_i] & PTE_P)) {
+        pte_t* new_pd = alloc_table();
+        pdpt[pdpt_i] = virt_to_phys((uint64_t)new_pd) | PTE_P | PTE_RW;
+    }
+    pte_t* pd = (pte_t*)phys_to_virt(pdpt[pdpt_i] & 0x000ffffffffff000ULL);
+
+    if (!(pd[pd_i] & PTE_P)) {
+        pte_t* new_pt = alloc_table();
+        pd[pd_i] = virt_to_phys((uint64_t)new_pt) | PTE_P | PTE_RW;
+    }
+    pte_t* pt = (pte_t*)phys_to_virt(pd[pd_i] & 0x000ffffffffff000ULL);
+
+    pt[pt_i] = (phys & 0x000ffffffffff000ULL) | (flags & 0xFFF) | PTE_P;
+    return 0;
+}
+
+int map_range(uint64_t virt, uint64_t phys, size_t count, uint64_t flags)
+{
+    for (size_t i = 0; i < count; i++) {
+        int res = map_page(virt + i * PAGE_SIZE, phys + i * PAGE_SIZE, flags);
+        if (res < 0)
+            return res;
+    }
+    return 0;
+}
+
+int unmap(uint64_t virt)
+{
+    uint16_t pml4_i = (virt >> 39) & 0x1FF;
+    uint16_t pdpt_i = (virt >> 30) & 0x1FF;
+    uint16_t pd_i   = (virt >> 21) & 0x1FF;
+    uint16_t pt_i   = (virt >> 12) & 0x1FF;
+
+    if (!(pml4[pml4_i] & PTE_P))
+        return -1;
+    pte_t* pdpt = (pte_t*)phys_to_virt(pml4[pml4_i] & 0x000ffffffffff000ULL);
+    if (!(pdpt[pdpt_i] & PTE_P))
+        return -1;
+    pte_t* pd = (pte_t*)phys_to_virt(pdpt[pdpt_i] & 0x000ffffffffff000ULL);
+    if (!(pd[pd_i] & PTE_P))
+        return -1;
+    pte_t* pt = (pte_t*)phys_to_virt(pd[pd_i] & 0x000ffffffffff000ULL);
+    pt[pt_i] = 0;
+    return 0;
+}

--- a/src/memory/paging/paging64.h
+++ b/src/memory/paging/paging64.h
@@ -1,0 +1,32 @@
+#ifndef PAGING64_H
+#define PAGING64_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+/* 64-bit page table entry */
+typedef uint64_t pte_t;
+
+/* Flag masks */
+#define PTE_P   (1ull << 0)  /* Present */
+#define PTE_RW  (1ull << 1)  /* Read/write */
+#define PTE_US  (1ull << 2)  /* User/supervisor */
+#define PTE_PWT (1ull << 3)  /* Write-through */
+#define PTE_PCD (1ull << 4)  /* Cache disable */
+#define PTE_A   (1ull << 5)  /* Accessed */
+#define PTE_D   (1ull << 6)  /* Dirty */
+#define PTE_PS  (1ull << 7)  /* Page size */
+#define PTE_G   (1ull << 8)  /* Global */
+#define PTE_NX  (1ull << 63) /* No execute */
+
+#define PAGE_SIZE 0x1000
+
+void paging64_init(uint64_t hhdm_base);
+
+int map_page(uint64_t virt, uint64_t phys, uint64_t flags);
+int map_range(uint64_t virt, uint64_t phys, size_t count, uint64_t flags);
+int unmap(uint64_t virt);
+uint64_t virt_to_phys(uint64_t virt);
+uint64_t phys_to_virt(uint64_t phys);
+
+#endif


### PR DESCRIPTION
## Summary
- Introduce 64-bit page table entry definitions and flag masks
- Implement early-allocating mapper with map/unmap/translation helpers
- Wire paging init into kernel and enable NX bit

## Testing
- `make ARCH=x86_64 all` *(fails: i686-elf-gcc: fatal error: cannot execute 'cc1': execvp: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6897cd51dc24832498997da6190b2d81