### PR TITLE
Add 64-bit IDT and TSS setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,22 +170,22 @@ all: user_programs dirs ./bin/boot.bin ./bin/kernel.bin
 	$(CC) $(INCLUDES) $(FLAGS) -std=gnu99 -c ./src/loader/formats/elf.c -o ./build/loader/formats/elf.o
 
 ./build/loader/formats/elfloader.o: ./src/loader/formats/elfloader.c
-	        $(CC) $(INCLUDES) $(FLAGS) -std=gnu99 -c ./src/loader/formats/elfloader.c -o ./build/loader/formats/elfloader.o
+	$(CC) $(INCLUDES) $(FLAGS) -std=gnu99 -c ./src/loader/formats/elfloader.c -o ./build/loader/formats/elfloader.o
 
 ./build/isr80h/isr80h.o: ./src/isr80h/isr80h.c
-		$(CC) $(INCLUDES) $(FLAGS) -std=gnu99 -c ./src/isr80h/isr80h.c -o ./build/isr80h/isr80h.o
+	$(CC) $(INCLUDES) $(FLAGS) -std=gnu99 -c ./src/isr80h/isr80h.c -o ./build/isr80h/isr80h.o
 
 ./build/isr80h/io.o: ./src/isr80h/io.c
-		$(CC) $(INCLUDES) $(FLAGS) -std=gnu99 -c ./src/isr80h/io.c -o ./build/isr80h/io.o
+	$(CC) $(INCLUDES) $(FLAGS) -std=gnu99 -c ./src/isr80h/io.c -o ./build/isr80h/io.o
 
 ./build/isr80h/heap.o: ./src/isr80h/heap.c
-		                $(CC) $(INCLUDES) $(FLAGS) -std=gnu99 -c ./src/isr80h/heap.c -o ./build/isr80h/heap.o
+	$(CC) $(INCLUDES) $(FLAGS) -std=gnu99 -c ./src/isr80h/heap.c -o ./build/isr80h/heap.o
 
 ./build/isr80h/misc.o: ./src/isr80h/misc.c
-		$(CC) $(INCLUDES) $(FLAGS) -std=gnu99 -c ./src/isr80h/misc.c -o ./build/isr80h/misc.o
+	$(CC) $(INCLUDES) $(FLAGS) -std=gnu99 -c ./src/isr80h/misc.c -o ./build/isr80h/misc.o
 
 ./build/isr80h/process.o: ./src/isr80h/process.c
-		                $(CC) $(INCLUDES) $(FLAGS) -std=gnu99 -c ./src/isr80h/process.c -o ./build/isr80h/process.o
+	$(CC) $(INCLUDES) $(FLAGS) -std=gnu99 -c ./src/isr80h/process.c -o ./build/isr80h/process.o
 
 clean: user_programs_clean
 	rm -rf ./bin/boot.bin
@@ -211,8 +211,29 @@ ifeq ($(ARCH),x86_64)
 build/kernel64.asm.o: src/kernel64.asm
 	nasm -f elf64 -g src/kernel64.asm -o build/kernel64.asm.o
 
-bin/kernel64.bin: build/kernel64.asm.o build/kernel64.o
-	$(LD) $(LDFLAGS) build/kernel64.asm.o build/kernel64.o -o bin/kernel64.bin
+build/memory/paging/paging64.o: src/memory/paging/paging64.c
+	$(CC) $(KERNEL_CFLAGS) -I./src -c src/memory/paging/paging64.c -o build/memory/paging/paging64.o
+
+build/gdt/gdt64.o: src/gdt/gdt64.c
+	$(CC) $(KERNEL_CFLAGS) -I./src -c src/gdt/gdt64.c -o build/gdt/gdt64.o
+
+build/gdt/gdt64.asm.o: src/gdt/gdt64.asm
+	nasm -f elf64 -g src/gdt/gdt64.asm -o build/gdt/gdt64.asm.o
+
+build/idt64.o: src/idt/idt64.c
+	$(CC) $(KERNEL_CFLAGS) -I./src -c src/idt/idt64.c -o build/idt64.o
+
+build/idt64.asm.o: src/idt/idt64.asm
+	nasm -f elf64 -g src/idt/idt64.asm -o build/idt64.asm.o
+
+build/task/tss64.asm.o: src/task/tss64.asm
+	nasm -f elf64 -g src/task/tss64.asm -o build/task/tss64.asm.o
+
+build/task/process.o: src/task/process.c
+	$(CC) $(KERNEL_CFLAGS) -I./src -c src/task/process.c -o build/task/process.o
+
+bin/kernel64.bin: build/kernel64.asm.o build/kernel64.o build/memory/paging/paging64.o build/gdt/gdt64.asm.o build/gdt/gdt64.o build/idt64.o build/idt64.asm.o build/task/tss64.asm.o build/task/process.o
+	$(LD) $(LDFLAGS) build/kernel64.asm.o build/kernel64.o build/memory/paging/paging64.o build/gdt/gdt64.asm.o build/gdt/gdt64.o build/idt64.o build/idt64.asm.o build/task/tss64.asm.o build/task/process.o -o bin/kernel64.bin
 endif
 
 build/boot64/boot.o: src/boot64/boot.asm

--- a/src/gdt/gdt64.asm
+++ b/src/gdt/gdt64.asm
@@ -4,13 +4,21 @@ section .asm
 
 global gdt64
 global gdt64_descriptor
+extern tss64
 
 gdt64:
     dq 0                        ; Null descriptor
     dq 0x00af9a000000ffff       ; 64-bit code segment
     dq 0x00af92000000ffff       ; 64-bit data segment
-    dq 0                        ; TSS descriptor (low 8 bytes)
-    dq 0                        ; TSS descriptor (high 8 bytes)
+    ; TSS descriptor
+    dw 0x0067                   ; limit
+    dw tss64 & 0xFFFF           ; base 0:15
+    db (tss64 >> 16) & 0xFF     ; base 16:23
+    db 0x89                     ; type (available 64-bit TSS)
+    db ((0x0067 >> 16) & 0xF)   ; limit 16:19 and flags
+    db (tss64 >> 24) & 0xFF     ; base 24:31
+    dd tss64 >> 32              ; base 32:63
+    dd 0                        ; reserved
 
 gdt64_end:
 

--- a/src/idt/idt64.asm
+++ b/src/idt/idt64.asm
@@ -1,0 +1,19 @@
+[BITS 64]
+
+section .text
+
+global idt64_load
+
+idt64_load:
+    mov rax, rdi
+    lidt [rax]
+    ret
+
+default_interrupt:
+    iretq
+
+section .data
+
+global interrupt_pointer_table
+interrupt_pointer_table:
+    times 256 dq default_interrupt

--- a/src/idt/idt64.c
+++ b/src/idt/idt64.c
@@ -1,0 +1,32 @@
+#include "idt64.h"
+#include "gdt/gdt.h"
+
+static struct idt64_desc idt64_descriptors[IDT64_TOTAL_DESCRIPTORS];
+static struct idtr64_desc idtr64_descriptor;
+
+extern void* interrupt_pointer_table[IDT64_TOTAL_DESCRIPTORS];
+extern void idt64_load(struct idtr64_desc* ptr);
+
+static void idt64_set(int interrupt_no, void* address)
+{
+    struct idt64_desc* desc = &idt64_descriptors[interrupt_no];
+    uint64_t addr = (uint64_t)address;
+    desc->offset_low = addr & 0xFFFF;
+    desc->selector = GDT64_KERNEL_CODE_SELECTOR;
+    desc->ist = 0;
+    desc->type_attr = 0x8E; /* present, ring0, interrupt gate */
+    desc->offset_mid = (addr >> 16) & 0xFFFF;
+    desc->offset_high = (uint32_t)(addr >> 32);
+    desc->zero = 0;
+}
+
+void idt64_init(void)
+{
+    idtr64_descriptor.limit = sizeof(idt64_descriptors) - 1;
+    idtr64_descriptor.base = (uint64_t)&idt64_descriptors;
+
+    for (int i = 0; i < IDT64_TOTAL_DESCRIPTORS; i++)
+        idt64_set(i, interrupt_pointer_table[i]);
+
+    idt64_load(&idtr64_descriptor);
+}

--- a/src/idt/idt64.h
+++ b/src/idt/idt64.h
@@ -1,0 +1,25 @@
+#ifndef IDT64_H
+#define IDT64_H
+
+#include <stdint.h>
+
+#define IDT64_TOTAL_DESCRIPTORS 256
+
+struct idt64_desc {
+    uint16_t offset_low;
+    uint16_t selector;
+    uint8_t ist;
+    uint8_t type_attr;
+    uint16_t offset_mid;
+    uint32_t offset_high;
+    uint32_t zero;
+} __attribute__((packed));
+
+struct idtr64_desc {
+    uint16_t limit;
+    uint64_t base;
+} __attribute__((packed));
+
+void idt64_init(void);
+
+#endif

--- a/src/kernel64.c
+++ b/src/kernel64.c
@@ -1,5 +1,8 @@
 #include <stdint.h>
 #include "memory/paging/paging64.h"
+#include "gdt/gdt.h"
+#include "idt/idt64.h"
+#include "task/process.h"
 
 #define HHDM_BASE 0xffff800000000000ULL
 #define DIRECT_MAP_PAGES (1024*1024) /* map first 1 GiB */
@@ -8,4 +11,7 @@ void kernel_main(void)
 {
     paging64_init(HHDM_BASE);
     map_range(HHDM_BASE, 0, DIRECT_MAP_PAGES, PTE_RW | PTE_NX);
+    gdt64_init();
+    idt64_init();
+    tss64_init(HHDM_BASE + 0x200000);
 }

--- a/src/task/process.c
+++ b/src/task/process.c
@@ -1,3 +1,28 @@
+#ifdef __x86_64__
+#include "task/tss.h"
+#include "gdt/gdt.h"
+#include <stddef.h>
+
+extern struct tss64 tss64;
+extern void tss64_load(uint16_t tss_segment);
+
+void tss64_init(uint64_t rsp0)
+{
+    uint64_t* tss = (uint64_t*)&tss64;
+    for (size_t i = 0; i < sizeof(struct tss64)/sizeof(uint64_t); i++)
+        tss[i] = 0;
+    tss64.rsp0 = rsp0;
+    tss64.ist1 = rsp0;
+    tss64.ist2 = rsp0;
+    tss64.ist3 = rsp0;
+    tss64.ist4 = rsp0;
+    tss64.ist5 = rsp0;
+    tss64.ist6 = rsp0;
+    tss64.ist7 = rsp0;
+    tss64_load(GDT64_TSS_SELECTOR);
+}
+
+#else
 #include "process.h"
 #include "config.h"
 #include "status.h"
@@ -701,3 +726,4 @@ out:
     }
     return res;
 }
+#endif

--- a/src/task/process.h
+++ b/src/task/process.h
@@ -82,4 +82,8 @@ void process_get_arguments(struct process* process, int* argc, char*** argv);
 int process_inject_arguments(struct process* process, struct command_argument* root_argument);
 int process_terminate(struct process* process);
 
+#ifdef __x86_64__
+void tss64_init(uint64_t rsp0);
+#endif
+
 #endif

--- a/src/task/tss.h
+++ b/src/task/tss.h
@@ -35,4 +35,27 @@ struct tss {
 
 void tss_load(uint16_t tss_segment);
 
+#ifdef __x86_64__
+struct tss64 {
+    uint32_t reserved0;
+    uint32_t reserved1;
+    uint64_t rsp0;
+    uint64_t rsp1;
+    uint64_t rsp2;
+    uint64_t reserved2;
+    uint64_t ist1;
+    uint64_t ist2;
+    uint64_t ist3;
+    uint64_t ist4;
+    uint64_t ist5;
+    uint64_t ist6;
+    uint64_t ist7;
+    uint64_t reserved3;
+    uint16_t reserved4;
+    uint16_t io_map_base;
+} __attribute__((packed));
+
+void tss64_load(uint16_t tss_segment);
+#endif
+
 #endif

--- a/src/task/tss64.asm
+++ b/src/task/tss64.asm
@@ -1,0 +1,32 @@
+[BITS 64]
+
+section .data
+
+global tss64
+
+tss64:
+    dd 0           ; reserved0
+    dd 0           ; pad
+    dq 0           ; rsp0
+    dq 0           ; rsp1
+    dq 0           ; rsp2
+    dq 0           ; reserved1
+    dq 0           ; ist1
+    dq 0           ; ist2
+    dq 0           ; ist3
+    dq 0           ; ist4
+    dq 0           ; ist5
+    dq 0           ; ist6
+    dq 0           ; ist7
+    dq 0           ; reserved2
+    dw 0           ; reserved3
+    dw 0           ; io map base
+
+section .text
+
+global tss64_load
+
+tss64_load:
+    mov ax, di
+    ltr ax
+    ret


### PR DESCRIPTION
## Summary
- Implement 64-bit interrupt descriptor table with 16-byte gate entries and `lidt` loader.
- Introduce a 64-bit TSS with `rsp0` and IST stacks, wired into the GDT and initialized at boot.
- Extend 64-bit kernel startup to load the new GDT, IDT and TSS; update build scripts for new sources.

## Testing
- `bash build-toolchain.sh` *(failed: download in progress, aborted)*
- `make ARCH=x86_64 CROSS_PREFIX= vana64` *(failed: ld reports `i386 architecture of input file build/boot64/boot.o is incompatible`)*

------
https://chatgpt.com/codex/tasks/task_e_6897e55d622c8324a049596b4e211d90