### PR TITLE
Map kernel sections with page permissions

### DIFF
--- a/src/kernel64.c
+++ b/src/kernel64.c
@@ -1,4 +1,5 @@
 #include <stdint.h>
+#include <stddef.h>
 #include "memory/paging/paging64.h"
 #include "gdt/gdt.h"
 #include "idt/idt64.h"
@@ -8,10 +9,30 @@
 #define HHDM_BASE 0xffff800000000000ULL
 #define DIRECT_MAP_PAGES (1024*1024) /* map first 1 GiB */
 
+extern char _text[], _etext[], _data[], _edata[], _bss[], _ebss[], _phys_to_virt_offset[];
+
+static size_t pages_count(uint64_t start, uint64_t end)
+{
+    return (end - start + PAGE_SIZE - 1) / PAGE_SIZE;
+}
+
 void kernel_main(void)
 {
     paging64_init(HHDM_BASE);
     map_range(HHDM_BASE, 0, DIRECT_MAP_PAGES, PTE_RW | PTE_NX);
+
+    uint64_t offset = (uint64_t)_phys_to_virt_offset;
+
+    /* Map kernel .text as RX */
+    map_range((uint64_t)_text, (uint64_t)_text - offset,
+              pages_count((uint64_t)_text, (uint64_t)_etext), 0);
+
+    /* Map .data and .bss as RW and NX */
+    map_range((uint64_t)_data, (uint64_t)_data - offset,
+              pages_count((uint64_t)_data, (uint64_t)_edata), PTE_RW | PTE_NX);
+    map_range((uint64_t)_bss, (uint64_t)_bss - offset,
+              pages_count((uint64_t)_bss, (uint64_t)_ebss), PTE_RW | PTE_NX);
+
     gdt64_init();
     idt64_init();
     tss64_init(HHDM_BASE + 0x200000);

--- a/src/linker64.ld
+++ b/src/linker64.ld
@@ -19,9 +19,9 @@ SECTIONS
 
     .text : ALIGN(0x1000) AT(KERNEL_PHYS)
     {
-        _text = .;
+        PROVIDE(_text = .);
         *(.text*)
-        _etext = .;
+        PROVIDE(_etext = .);
     } :text
 
     .rodata : ALIGN(0x1000) AT(KERNEL_PHYS + (ADDR(.rodata) - KERNEL_VMA))
@@ -31,17 +31,17 @@ SECTIONS
 
     .data : ALIGN(0x1000) AT(KERNEL_PHYS + (ADDR(.data) - KERNEL_VMA))
     {
-        _data = .;
+        PROVIDE(_data = .);
         *(.data*)
-        _edata = .;
+        PROVIDE(_edata = .);
     } :data
 
     .bss : ALIGN(0x1000) (NOLOAD) AT(KERNEL_PHYS + (ADDR(.bss) - KERNEL_VMA))
     {
-        _bss = .;
+        PROVIDE(_bss = .);
         *(COMMON)
         *(.bss*)
-        _ebss = .;
+        PROVIDE(_ebss = .);
     } :data
 
     .asm : ALIGN(0x1000) AT(KERNEL_PHYS + (ADDR(.asm) - KERNEL_VMA))


### PR DESCRIPTION
## Summary
- expose linker symbols for text, data, and bss sections
- map kernel text as RX and data/bss as RW+NX in `kernel_main`

## Testing
- `make ARCH=x86_64 CROSS_PREFIX=x86_64-linux-gnu vana64` *(fails: i386 architecture of input file `build/boot64/boot.o` is incompatible with i386:x86-64 output)*
- `make ARCH=x86_64 CROSS_PREFIX=x86_64-linux-gnu bin/kernel64.bin` *(fails: config.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6897ff0bee788324b0d670d2564b3fa2