### PR TITLE
Add x86_64 task switch routine

### DIFF
--- a/src/task/task.c
+++ b/src/task/task.c
@@ -9,6 +9,10 @@
 #include "loader/formats/elfloader.h"
 #include "idt/idt.h"
 
+#ifdef __x86_64__
+/* Assembly helper that restores registers and returns to user mode. */
+extern void task_switch64(struct registers* regs);
+#endif
 /*
  * Pointer to the task that currently owns the CPU. The scheduler keeps
  * tasks in a doubly linked list and `current_task` always references the
@@ -153,7 +157,11 @@ void task_next()
     }
 
     task_switch(next_task);
+#ifdef __x86_64__
+    task_switch64(&next_task->registers);
+#else
     task_return(&next_task->registers);
+#endif
 }
 
 /*
@@ -280,7 +288,11 @@ void task_run_first_ever_task()
     }
 
     task_switch(task_head);
+#ifdef __x86_64__
+    task_switch64(&task_head->registers);
+#else
     task_return(&task_head->registers);
+#endif
 }
 
 /*

--- a/src/task/task64.asm
+++ b/src/task/task64.asm
@@ -1,0 +1,39 @@
+[BITS 64]
+
+section .text
+
+global task_switch64
+
+; void task_switch64(struct registers* regs)
+; Pointer to regs is passed in RDI
+
+task_switch64:
+    ; Save base pointer to r11
+    mov r11, rdi
+
+    ; Restore general purpose registers
+    mov r15, [r11 + 0]
+    mov r14, [r11 + 8]
+    mov r13, [r11 + 16]
+    mov r12, [r11 + 24]
+    mov rbx, [r11 + 32]
+    mov rbp, [r11 + 40]
+    mov rdi, [r11 + 48]
+    mov rsi, [r11 + 56]
+    mov rdx, [r11 + 64]
+    mov rcx, [r11 + 72]
+    mov r8,  [r11 + 80]
+    mov r9,  [r11 + 88]
+    mov rax, [r11 + 96]
+
+    ; Prepare rflags with interrupts enabled
+    mov r10, [r11 + 120]
+    or r10, 0x200
+
+    ; Push return frame for iretq
+    push qword [r11 + 136]    ; ss
+    push qword [r11 + 128]    ; rsp
+    push r10                  ; rflags
+    push qword [r11 + 112]    ; cs
+    push qword [r11 + 104]    ; rip
+    iretq


### PR DESCRIPTION
## Summary
- add 64-bit `task_switch64` assembly helper for context switches
- call new helper from task scheduler when building for x86_64

## Testing
- `bash ./build-toolchain.sh` *(attempted; lengthy build process)*
- `make`


------
https://chatgpt.com/codex/tasks/task_e_6898079f28ac8324ac168cc0b6659d4b