### PR TITLE
Forward syscall registers to C dispatcher

### DIFF
--- a/src/syscall/syscall.asm
+++ b/src/syscall/syscall.asm
@@ -10,17 +10,28 @@ extern syscall_dispatch
 extern tss64
 
 syscall_entry:
-    mov rdi, rax                ; syscall number -> first argument
     swapgs
     mov [syscall_user_rsp], rsp ; save user stack pointer
     mov rsp, [tss64 + 8]        ; switch to kernel stack (rsp0)
-    sub rsp, 8                  ; maintain 16-byte alignment
+
     push rcx                    ; save return RIP
     push r11                    ; save RFLAGS
+    push r9                     ; sixth argument
+
+    mov r11, rdi                ; preserve first argument
+    mov rcx, rdx                ; third argument
+    mov rdx, rsi                ; second argument
+    mov rsi, r11                ; first argument
+    mov rdi, rax                ; syscall number
+    mov r11, r8                 ; save fifth argument
+    mov r8, r10                 ; fourth argument
+    mov r9, r11                 ; fifth argument
+
     call syscall_dispatch       ; dispatch based on syscall number
+
+    add rsp, 8                  ; discard sixth argument
     pop r11                     ; restore RFLAGS
     pop rcx                     ; restore return RIP
-    add rsp, 8                  ; remove alignment padding
     mov rsp, [syscall_user_rsp] ; restore user stack
     swapgs
     sysretq

--- a/src/syscall/syscall.c
+++ b/src/syscall/syscall.c
@@ -9,14 +9,16 @@ void syscall_register(int num, syscall_handler_t handler)
         syscall_table[num] = handler;
 }
 
-uint64_t syscall_dispatch(uint64_t num)
+uint64_t syscall_dispatch(uint64_t num,
+                          uint64_t arg1, uint64_t arg2, uint64_t arg3,
+                          uint64_t arg4, uint64_t arg5, uint64_t arg6)
 {
     syscall_handler_t handler = 0;
     if (num < 256)
         handler = syscall_table[num];
     if (!handler)
         return (uint64_t)-1;
-    return handler();
+    return handler(arg1, arg2, arg3, arg4, arg5, arg6);
 }
 
 static inline void wrmsr(uint32_t msr, uint64_t val)

--- a/src/syscall/syscall.h
+++ b/src/syscall/syscall.h
@@ -3,10 +3,13 @@
 
 #include <stdint.h>
 
-typedef uint64_t (*syscall_handler_t)(void);
+typedef uint64_t (*syscall_handler_t)(uint64_t, uint64_t, uint64_t,
+                                      uint64_t, uint64_t, uint64_t);
 
 void syscall_register(int num, syscall_handler_t handler);
-uint64_t syscall_dispatch(uint64_t num);
+uint64_t syscall_dispatch(uint64_t num,
+                          uint64_t arg1, uint64_t arg2, uint64_t arg3,
+                          uint64_t arg4, uint64_t arg5, uint64_t arg6);
 void syscall_init(void);
 
 #endif


### PR DESCRIPTION
## Summary
- Forward six syscall argument registers from assembly entry to the C dispatcher
- Expand syscall dispatcher and handler prototypes to accept six arguments
- Adjust dispatcher to route arguments to handlers

## Testing
- `make vana64 ARCH=x86_64` *(fails: x86_64-elf-ld: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689813af1f5c8324b81625d61bd29b26