### PR TITLE
Add 64-bit port I/O routines

### DIFF
--- a/src/io/io.h
+++ b/src/io/io.h
@@ -1,9 +1,16 @@
 #ifndef IO_H
 #define IO_H
 
+#ifdef __x86_64__
 unsigned char insb(unsigned short port);
 unsigned short insw(unsigned short port);
 void outb(unsigned short port, unsigned char val);
 void outw(unsigned short port, unsigned short val);
+#else
+unsigned char insb(unsigned short port);
+unsigned short insw(unsigned short port);
+void outb(unsigned short port, unsigned char val);
+void outw(unsigned short port, unsigned short val);
+#endif
 
 #endif

--- a/src/io/io64.asm
+++ b/src/io/io64.asm
@@ -1,0 +1,50 @@
+section .text
+
+global insb
+global insw
+global outb
+global outw
+
+insb:
+    push rbp
+    mov rbp, rsp
+
+    xor eax, eax
+    mov dx, di
+    in al, dx
+
+    pop rbp
+    ret
+
+insw:
+    push rbp
+    mov rbp, rsp
+
+    xor eax, eax
+    mov dx, di
+    in ax, dx
+
+    pop rbp
+    ret
+
+outb:
+    push rbp
+    mov rbp, rsp
+
+    mov dx, di
+    mov al, sil
+    out dx, al
+
+    pop rbp
+    ret
+
+outw:
+    push rbp
+    mov rbp, rsp
+
+    mov dx, di
+    mov ax, si
+    out dx, ax
+
+    pop rbp
+    ret


### PR DESCRIPTION
## Summary
- Implement 64-bit port I/O helpers (insb, insw, outb, outw) using rdx/rax.
- Gate I/O declarations with `__x86_64__` to reference the 64-bit routines.

## Testing
- `nasm -f elf64 src/io/io64.asm -o /tmp/io64.o`
- `ARCH=x86_64 make build/io.o` *(fails: fatal unable to open output file `./build/io.o`)*

------
https://chatgpt.com/codex/tasks/task_e_68981636323c8324a0377d1f73fa1b4c