### PR TITLE
Add ELF64 loader and integrate with x86_64 build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ FILES = ./build/kernel.asm.o \
         ./build/fs/pparser.o \
         ./build/fs/fat/fat16.o
 INCLUDES = -I./src -I./src/gdt -I./src/task -I./src/idt -I./src/fs -I./src/fs/fat -I./src/loader/formats -I./src/isr80h
-BUILD_DIRS = ./bin ./build/memory/heap ./build/memory/paging ./build/keyboard ./build/disk ./build/fs ./build/fs/fat ./build/task ./build/loader/formats ./build/isr80h ./build/boot64 ./build/syscall
+BUILD_DIRS = ./bin ./build/memory/heap ./build/memory/paging ./build/keyboard ./build/disk ./build/fs ./build/fs/fat ./build/task ./build/loader ./build/loader/formats ./build/isr80h ./build/boot64 ./build/syscall
 FLAGS = -g -ffreestanding -falign-jumps -falign-functions -falign-labels -falign-loops -fstrength-reduce -fomit-frame-pointer -finline-functions -Wno-unused-function -fno-builtin -Werror -Wno-unused-label -Wno-cpp -Wno-unused-parameter -nostdlib -nostartfiles -nodefaultlibs -Wall -O0 -Iinc -fno-pie -no-pie
 
 # Directory where the FAT image will be mounted
@@ -244,12 +244,15 @@ build/syscall/syscall.o: src/syscall/syscall.c
 build/syscall/syscall.asm.o: src/syscall/syscall.asm
 	nasm -f elf64 -g src/syscall/syscall.asm -o build/syscall/syscall.asm.o
 
-bin/kernel64.bin: build/kernel64.asm.o build/kernel64.o build/memory/paging/paging64.o build/gdt/gdt64.asm.o build/gdt/gdt64.o build/idt64.o build/idt64.asm.o build/page_fault.o build/page_fault.asm.o build/task/tss64.asm.o build/task/process.o build/syscall/syscall.o build/syscall/syscall.asm.o
-	$(LD) $(LDFLAGS) build/kernel64.asm.o build/kernel64.o build/memory/paging/paging64.o build/gdt/gdt64.asm.o build/gdt/gdt64.o build/idt64.o build/idt64.asm.o build/page_fault.o build/page_fault.asm.o build/task/tss64.asm.o build/task/process.o build/syscall/syscall.o build/syscall/syscall.asm.o -o bin/kernel64.bin
+bin/kernel64.bin: build/kernel64.asm.o build/kernel64.o build/memory/paging/paging64.o build/gdt/gdt64.asm.o build/gdt/gdt64.o build/idt64.o build/idt64.asm.o build/page_fault.o build/page_fault.asm.o build/task/tss64.asm.o build/task/process.o build/syscall/syscall.o build/syscall/syscall.asm.o build/loader/elf64.o
+	$(LD) $(LDFLAGS) build/kernel64.asm.o build/kernel64.o build/memory/paging/paging64.o build/gdt/gdt64.asm.o build/gdt/gdt64.o build/idt64.o build/idt64.asm.o build/page_fault.o build/page_fault.asm.o build/task/tss64.asm.o build/task/process.o build/syscall/syscall.o build/syscall/syscall.asm.o build/loader/elf64.o -o bin/kernel64.bin
 endif
 
 build/boot64/boot.o: src/boot64/boot.asm
 	nasm -f elf32 -g src/boot64/boot.asm -o build/boot64/boot.o
+
+build/loader/elf64.o: src/loader/elf64.c
+	$(CC) $(KERNEL_CFLAGS) -I./src -c src/loader/elf64.c -o build/loader/elf64.o
 
 bin/boot64.bin: build/boot64/boot.o
 	$(LD) -Ttext 0x7c00 build/boot64/boot.o -o build/boot64/boot.elf

--- a/src/loader/elf64.c
+++ b/src/loader/elf64.c
@@ -1,0 +1,250 @@
+#include "formats/elfloader.h"
+#include "fs/file.h"
+#include "status.h"
+#include <stdbool.h>
+#include "memory/memory.h"
+#include "memory/heap/kheap.h"
+#include "string/string.h"
+
+/*
+ * Minimal ELF64 loader. Responsible for validating headers and
+ * recording the address ranges of PT_LOAD segments so that the
+ * caller can map them into memory with appropriate permissions.
+ */
+
+static const char elf_signature[] = {0x7f, 'E', 'L', 'F'};
+
+static bool elf_valid_signature(void* buffer)
+{
+    return memcmp(buffer, (void*) elf_signature, sizeof(elf_signature)) == 0;
+}
+
+static bool elf_valid_class(struct elf_header* header)
+{
+    return header->e_ident[EI_CLASS] == ELFCLASS64;
+}
+
+static bool elf_valid_encoding(struct elf_header* header)
+{
+    return header->e_ident[EI_DATA] == ELFDATA2LSB;
+}
+
+static bool elf_is_executable(struct elf_header* header)
+{
+    return header->e_type == ET_EXEC;
+}
+
+static bool elf_has_program_header(struct elf_header* header)
+{
+    return header->e_phoff != 0;
+}
+
+void* elf_memory(struct elf_file* file)
+{
+    return file->elf_memory;
+}
+
+struct elf_header* elf_header(struct elf_file* file)
+{
+    return file->elf_memory;
+}
+
+struct elf64_shdr* elf_sheader(struct elf_header* header)
+{
+    return (struct elf64_shdr*)((uint64_t)header + header->e_shoff);
+}
+
+struct elf64_phdr* elf_pheader(struct elf_header* header)
+{
+    if (header->e_phoff == 0)
+        return 0;
+    return (struct elf64_phdr*)((uint64_t)header + header->e_phoff);
+}
+
+struct elf64_phdr* elf_program_header(struct elf_header* header, int index)
+{
+    return &elf_pheader(header)[index];
+}
+
+struct elf64_shdr* elf_section(struct elf_header* header, int index)
+{
+    return &elf_sheader(header)[index];
+}
+
+void* elf_phdr_phys_address(struct elf_file* file, struct elf64_phdr* phdr)
+{
+    return elf_memory(file) + phdr->p_offset;
+}
+
+void* elf_virtual_base(struct elf_file* file)
+{
+    return file->virtual_base_address;
+}
+
+void* elf_virtual_end(struct elf_file* file)
+{
+    return file->virtual_end_address;
+}
+
+void* elf_phys_base(struct elf_file* file)
+{
+    return file->physical_base_address;
+}
+
+void* elf_phys_end(struct elf_file* file)
+{
+    return file->physical_end_address;
+}
+
+static int elf_validate_loaded(struct elf_header* header)
+{
+    return (elf_valid_signature(header) &&
+            elf_valid_class(header) &&
+            elf_valid_encoding(header) &&
+            elf_has_program_header(header) &&
+            elf_is_executable(header)) ? VANA_ALL_OK : -EINFORMAT;
+}
+
+static int elf_process_phdr_pt_load(struct elf_file* file, struct elf64_phdr* phdr)
+{
+    if (file->virtual_base_address >= (void*) phdr->p_vaddr || file->virtual_base_address == 0)
+    {
+        file->virtual_base_address = (void*) phdr->p_vaddr;
+        file->physical_base_address = elf_memory(file) + phdr->p_offset;
+    }
+
+    uint64_t end_virtual = phdr->p_vaddr + phdr->p_memsz;
+    if (file->virtual_end_address <= (void*) end_virtual || file->virtual_end_address == 0)
+    {
+        file->virtual_end_address = (void*) end_virtual;
+        file->physical_end_address = elf_memory(file) + phdr->p_offset + phdr->p_filesz;
+    }
+
+    return 0;
+}
+
+static int elf_process_pheader(struct elf_file* file, struct elf64_phdr* phdr)
+{
+    int res = 0;
+    switch(phdr->p_type)
+    {
+        case PT_LOAD:
+            res = elf_process_phdr_pt_load(file, phdr);
+        break;
+    }
+    return res;
+}
+
+static int elf_process_pheaders(struct elf_file* file)
+{
+    int res = 0;
+    struct elf_header* header = elf_header(file);
+    for (int i = 0; i < header->e_phnum; i++)
+    {
+        struct elf64_phdr* phdr = elf_program_header(header, i);
+        res = elf_process_pheader(file, phdr);
+        if (res < 0)
+            break;
+    }
+    return res;
+}
+
+static int elf_process_loaded(struct elf_file* file)
+{
+    int res = 0;
+    struct elf_header* header = elf_header(file);
+    res = elf_validate_loaded(header);
+    if (res < 0)
+        return res;
+
+    return elf_process_pheaders(file);
+}
+
+struct elf_file* elf_file_new()
+{
+    return kzalloc(sizeof(struct elf_file));
+}
+
+void elf_file_free(struct elf_file* file)
+{
+    if (!file)
+        return;
+
+    if (file->elf_memory)
+        kfree(file->elf_memory);
+
+    kfree(file);
+}
+
+void elf_close(struct elf_file* file)
+{
+    elf_file_free(file);
+}
+
+int elf_load(const char* filename, struct elf_file** file_out)
+{
+    int res = 0;
+    struct elf_file* elf_file = elf_file_new();
+    if (!elf_file)
+    {
+        res = -ENOMEM;
+        goto out;
+    }
+
+    strncpy(elf_file->filename, filename, sizeof(elf_file->filename));
+
+    FILE* fd = fopen(filename, "r");
+    if (!fd)
+    {
+        res = -EIO;
+        goto out;
+    }
+
+    fseek(fd, 0, SEEK_END);
+    int file_size = ftell(fd);
+    fseek(fd, 0, SEEK_SET);
+
+    void* ptr = kzalloc(file_size);
+    if (!ptr)
+    {
+        res = -ENOMEM;
+        fclose(fd);
+        goto out;
+    }
+
+    if (fread(ptr, file_size, 1, fd) != 1)
+    {
+        res = -EIO;
+        fclose(fd);
+        kfree(ptr);
+        goto out;
+    }
+
+    elf_file->in_memory_size = file_size;
+    elf_file->elf_memory = ptr;
+
+    fclose(fd);
+
+    res = elf_process_loaded(elf_file);
+    if (res < 0)
+    {
+        elf_file_free(elf_file);
+        goto out;
+    }
+
+    *file_out = elf_file;
+
+out:
+    return res;
+}
+
+void* elf_get_entry_ptr(struct elf_header* header)
+{
+    return (void*) header->e_entry;
+}
+
+uint64_t elf_get_entry(struct elf_header* header)
+{
+    return header->e_entry;
+}
+

--- a/src/loader/elf64.h
+++ b/src/loader/elf64.h
@@ -1,0 +1,112 @@
+#ifndef ELF64_H
+#define ELF64_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+/* Permission flags for program headers */
+#define PF_X 0x01
+#define PF_W 0x02
+#define PF_R 0x04
+
+/* Segment types */
+#define PT_NULL 0
+#define PT_LOAD 1
+#define PT_DYNAMIC 2
+#define PT_INTERP 3
+#define PT_NOTE 4
+#define PT_SHLIB 5
+#define PT_PHDR 6
+
+/* Section types */
+#define SHT_NULL 0
+#define SHT_PROGBITS 1
+#define SHT_SYMTAB 2
+#define SHT_STRTAB 3
+#define SHT_RELA 4
+#define SHT_HASH 5
+#define SHT_DYNAMIC 6
+#define SHT_NOTE 7
+#define SHT_NOBITS 8
+#define SHT_REL 9
+#define SHT_SHLIB 10
+#define SHT_DYNSYM 11
+
+#define ET_NONE 0
+#define ET_REL 1
+#define ET_EXEC 2
+#define ET_DYN 3
+#define ET_CORE 4
+
+#define EI_NIDENT 16
+#define EI_CLASS 4
+#define EI_DATA 5
+
+#define ELFCLASSNONE 0
+#define ELFCLASS32 1
+#define ELFCLASS64 2
+
+#define ELFDATANONE 0
+#define ELFDATA2LSB 1
+#define ELFDATA2MSB 2
+
+#define SHN_UNDEF 0
+
+typedef uint16_t elf64_half;
+typedef uint32_t elf64_word;
+typedef int32_t  elf64_sword;
+typedef uint64_t elf64_xword;
+typedef int64_t  elf64_sxword;
+typedef uint64_t elf64_addr;
+typedef uint64_t elf64_off;
+
+struct elf64_phdr
+{
+    elf64_word  p_type;
+    elf64_word  p_flags;
+    elf64_off   p_offset;
+    elf64_addr  p_vaddr;
+    elf64_addr  p_paddr;
+    elf64_xword p_filesz;
+    elf64_xword p_memsz;
+    elf64_xword p_align;
+} __attribute__((packed));
+
+struct elf64_shdr
+{
+    elf64_word  sh_name;
+    elf64_word  sh_type;
+    elf64_xword sh_flags;
+    elf64_addr  sh_addr;
+    elf64_off   sh_offset;
+    elf64_xword sh_size;
+    elf64_word  sh_link;
+    elf64_word  sh_info;
+    elf64_xword sh_addralign;
+    elf64_xword sh_entsize;
+} __attribute__((packed));
+
+/* 64-bit ELF header */
+struct elf_header
+{
+    unsigned char e_ident[EI_NIDENT];
+    elf64_half    e_type;
+    elf64_half    e_machine;
+    elf64_word    e_version;
+    elf64_addr    e_entry;
+    elf64_off     e_phoff;
+    elf64_off     e_shoff;
+    elf64_word    e_flags;
+    elf64_half    e_ehsize;
+    elf64_half    e_phentsize;
+    elf64_half    e_phnum;
+    elf64_half    e_shentsize;
+    elf64_half    e_shnum;
+    elf64_half    e_shstrndx;
+} __attribute__((packed));
+
+void* elf_get_entry_ptr(struct elf_header* header);
+uint64_t elf_get_entry(struct elf_header* header);
+
+#endif
+

--- a/src/loader/formats/elfloader.h
+++ b/src/loader/formats/elfloader.h
@@ -4,8 +4,13 @@
 #include <stdint.h>
 #include <stddef.h>
 
-#include "elf.h"
 #include "config.h"
+
+#ifdef __x86_64__
+#include "../elf64.h"
+#else
+#include "elf.h"
+#endif
 
 struct elf_file
 {
@@ -57,16 +62,36 @@ void* elf_phys_end(struct elf_file* file);
 /* Get a pointer to the ELF header within the file. */
 struct elf_header* elf_header(struct elf_file* file);
 /* Return the first section header entry. */
+#ifdef __x86_64__
+struct elf64_shdr* elf_sheader(struct elf_header* header);
+#else
 struct elf32_shdr* elf_sheader(struct elf_header* header);
+#endif
 /* Pointer to the raw ELF data in memory. */
 void* elf_memory(struct elf_file* file);
 /* Return the first program header entry. */
+#ifdef __x86_64__
+struct elf64_phdr* elf_pheader(struct elf_header* header);
+#else
 struct elf32_phdr* elf_pheader(struct elf_header* header);
+#endif
 /* Retrieve the program header at the given index. */
+#ifdef __x86_64__
+struct elf64_phdr* elf_program_header(struct elf_header* header, int index);
+#else
 struct elf32_phdr* elf_program_header(struct elf_header* header, int index);
+#endif
 /* Retrieve the section header at the given index. */
+#ifdef __x86_64__
+struct elf64_shdr* elf_section(struct elf_header* header, int index);
+#else
 struct elf32_shdr* elf_section(struct elf_header* header, int index);
+#endif
 /* Convert a program header into a physical address. */
+#ifdef __x86_64__
+void* elf_phdr_phys_address(struct elf_file* file, struct elf64_phdr* phdr);
+#else
 void* elf_phdr_phys_address(struct elf_file* file, struct elf32_phdr* phdr);
+#endif
 
 #endif


### PR DESCRIPTION
## Summary
- implement minimal ELF64 loader to parse headers and track PT_LOAD segments
- choose ELF64 structures in loader front end for ARCH=x86_64
- wire ELF64 loader into 64-bit build rules

## Testing
- `make build/loader/formats/elfloader.o` *(fails: i686-elf-gcc: cannot execute 'cc1')*
- `make ARCH=x86_64 build/loader/elf64.o` *(fails: x86_64-elf-gcc: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689817f9440c832492f0cac897156cf1